### PR TITLE
Optimize points/ranking calculation and introduce TipPoints constants

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,7 +76,7 @@ module ApplicationHelper
   # Pass `answer_set: false` for questions 3 & 4 when the admin has not yet
   # stored the correct answer — shows a neutral "not yet evaluated" label.
   def bonus_result_tag(correct, answer_set: true)
-    points = Users::UpdatePoints::BONUS_TIP_POINTS
+    points = TipPoints::BONUS
     if correct
       content_tag(:span, I18n.t('bonus_answer_correct', points: points), class: 'label success')
     elsif !answer_set

--- a/app/models/tip_points.rb
+++ b/app/models/tip_points.rb
@@ -1,0 +1,14 @@
+# Canonical point values awarded per tip.
+# These constants are the single source of truth used by scoring services,
+# ranking calculation, and query helpers.
+module TipPoints
+  PERFECT                = 8  # exact score for both teams
+  CORRECT_GOALS_ONE_TEAM = 5  # correct trend + exact goals for one team
+  CORRECT_GOALS          = 4  # correct trend + correct goal difference
+  CORRECT_TREND          = 3  # correct winner / draw only
+  NO_POINTS              = 0  # wrong or missing tip
+
+  BONUS = 8  # points awarded per correct bonus question answer
+
+  ALL_VALUES = [PERFECT, CORRECT_GOALS_ONE_TEAM, CORRECT_GOALS, CORRECT_TREND, NO_POINTS].freeze
+end

--- a/app/models/tips/tip_queries.rb
+++ b/app/models/tips/tip_queries.rb
@@ -49,5 +49,20 @@ module TipQueries
       Tip.where(game_id: game_ids).group(:user_id).sum(:tip_points)
     end
 
+    # Returns a hash: { user_id => total_tip_points } for ALL tips (no filter).
+    # Single query replacing N individual sum_tip_points_by_user_id calls.
+    def sum_tip_points_grouped_by_user_id
+      Tip.group(:user_id).sum(:tip_points)
+    end
+
+    # Returns a nested hash: { user_id => { tip_points => count } }
+    # Single query replacing N×5 individual all_by_user_id_and_tip_points count calls.
+    def counts_by_user_id_and_tip_points(point_values)
+      rows = Tip.where(tip_points: point_values).group(:user_id, :tip_points).count
+      result = Hash.new { |h, k| h[k] = Hash.new(0) }
+      rows.each { |(uid, pts), cnt| result[uid][pts] = cnt }
+      result
+    end
+
   end
 end

--- a/app/services/tips/update_points.rb
+++ b/app/services/tips/update_points.rb
@@ -4,8 +4,8 @@
 module Tips
   class UpdatePoints < BaseService
 
-    MAX_POINTS_PRO_TIP   = 8
-    POINTS_CORRECT_TREND = 3
+    MAX_POINTS_PRO_TIP   = TipPoints::PERFECT
+    POINTS_CORRECT_TREND = TipPoints::CORRECT_TREND
     EXTRA_POINT_GOALS    = 2
     EXTRA_POINT          = 1
 

--- a/app/services/users/update_points.rb
+++ b/app/services/users/update_points.rb
@@ -11,7 +11,7 @@
 module Users
   class UpdatePoints < BaseService
 
-    BONUS_TIP_POINTS = 8
+    BONUS_TIP_POINTS = TipPoints::BONUS
 
     def call
       update_user_points
@@ -61,33 +61,33 @@ module Users
 
     def update_user_points
       users = User.active
-      if users.present?
-        users.each do |user|
-          total_points  = ::TipQueries.sum_tip_points_by_user_id(user.id)
-          total_points  = 0 unless total_points.present?
+      return unless users.present?
 
-          bonus_tips_points = 0
-          if Tournament.finished?
-            bonus_tips_points = calculate_bonus_points(user)
-            total_points = total_points + bonus_tips_points
-          end
+      # Two bulk queries replace N×6 individual queries.
+      points_by_user   = ::TipQueries.sum_tip_points_grouped_by_user_id
+      counts_by_user   = ::TipQueries.counts_by_user_id_and_tip_points(TipPoints::ALL_VALUES)
+      tournament_done  = Tournament.finished?
 
-          count_8points = ::TipQueries.all_by_user_id_and_tip_points(user.id, 8).count
-          count_5points = ::TipQueries.all_by_user_id_and_tip_points(user.id, 5).count
-          count_4points = ::TipQueries.all_by_user_id_and_tip_points(user.id, 4).count
-          count_3points = ::TipQueries.all_by_user_id_and_tip_points(user.id, 3).count
-          count_0points = ::TipQueries.all_by_user_id_and_tip_points(user.id, 0).count
+      users.each do |user|
+        tip_points    = points_by_user[user.id] || 0
+        user_counts   = counts_by_user[user.id]
 
-          user.update_columns({:points => total_points,
-                               :bonus_points => bonus_tips_points,
-                               :count8points => count_8points,
-                               :count5points => count_5points,
-                               :count4points => count_4points,
-                               :count3points => count_3points,
-                               :count0points => count_0points,
-                              })
-          Rails.logger.debug("CALCULATE_USER_POINTS: #{user.name} - total points: #{total_points}") if Rails.logger.present?
+        bonus_tips_points = 0
+        if tournament_done
+          bonus_tips_points = calculate_bonus_points(user)
+          tip_points        = tip_points + bonus_tips_points
         end
+
+        user.update_columns({
+          points:       tip_points,
+          bonus_points: bonus_tips_points,
+          count8points: user_counts[TipPoints::PERFECT],
+          count5points: user_counts[TipPoints::CORRECT_GOALS_ONE_TEAM],
+          count4points: user_counts[TipPoints::CORRECT_GOALS],
+          count3points: user_counts[TipPoints::CORRECT_TREND],
+          count0points: user_counts[TipPoints::NO_POINTS],
+        })
+        Rails.logger.debug("CALCULATE_USER_POINTS: #{user.name} - total points: #{tip_points}") if Rails.logger.present?
       end
     end
   end

--- a/app/services/users/update_ranking_per_game.rb
+++ b/app/services/users/update_ranking_per_game.rb
@@ -2,22 +2,38 @@ module Users
   class UpdateRankingPerGame < UserBaseService
 
     def call
-      finished_games = ::GameQueries.all_finished_ordered_by_start_at_with_preload_tips
-      all_8point_tips = ::TipQueries.all_by_games_and_tip_points(finished_games, 8)
-      all_5point_tips = ::TipQueries.all_by_games_and_tip_points(finished_games, 5)
-      all_4point_tips = ::TipQueries.all_by_games_and_tip_points(finished_games, 4)
-      all_3point_tips = ::TipQueries.all_by_games_and_tip_points(finished_games, 3)
+      finished_games  = ::GameQueries.all_finished_ordered_by_start_at_with_preload_tips
+      all_8point_tips = ::TipQueries.all_by_games_and_tip_points(finished_games, TipPoints::PERFECT)
+      all_5point_tips = ::TipQueries.all_by_games_and_tip_points(finished_games, TipPoints::CORRECT_GOALS_ONE_TEAM)
+      all_4point_tips = ::TipQueries.all_by_games_and_tip_points(finished_games, TipPoints::CORRECT_GOALS)
+      all_3point_tips = ::TipQueries.all_by_games_and_tip_points(finished_games, TipPoints::CORRECT_TREND)
+
+      # Pre-build lookup hashes: { game_id => Set<user_id> }
+      # O(1) membership check instead of scanning the full array each iteration.
+      index_8 = build_game_user_index(all_8point_tips)
+      index_5 = build_game_user_index(all_5point_tips)
+      index_4 = build_game_user_index(all_4point_tips)
+      index_3 = build_game_user_index(all_3point_tips)
+
+      # Cumulative per-user counts that grow as we walk through games in order.
+      cum_8 = Hash.new(0)
+      cum_5 = Hash.new(0)
+      cum_4 = Hash.new(0)
+      cum_3 = Hash.new(0)
       used_game_ids = []
 
       finished_games.each do |game|
-        tips_for_game = game.tips
+        tips_for_game  = game.tips
         used_game_ids << game.id
 
-        ordered_user_id_and_ranking_comparison_value = get_ordered_user_id_and_ranking_comparison_value(all_8point_tips,
-                                                                                                        all_5point_tips,
-                                                                                                        all_4point_tips,
-                                                                                                        all_3point_tips,
-                                                                                                        used_game_ids)
+        # Increment only the users who scored on this specific game — O(users_in_game).
+        (index_8[game.id] || []).each { |uid| cum_8[uid] += 1 }
+        (index_5[game.id] || []).each { |uid| cum_5[uid] += 1 }
+        (index_4[game.id] || []).each { |uid| cum_4[uid] += 1 }
+        (index_3[game.id] || []).each { |uid| cum_3[uid] += 1 }
+
+        ordered_user_id_and_ranking_comparison_value =
+          get_ordered_user_id_and_ranking_comparison_value(cum_8, cum_5, cum_4, cum_3, used_game_ids)
 
         result_for_this_game     = {}
         place                    = 1
@@ -52,19 +68,21 @@ module Users
 
     private
 
-    def get_ordered_user_id_and_ranking_comparison_value(all_8point_tips, all_5point_tips, all_4point_tips, all_3point_tips, used_game_ids)
+    # Builds { game_id => [user_id, ...] } from a flat tip collection.
+    def build_game_user_index(tips)
+      tips.each_with_object(Hash.new { |h, k| h[k] = [] }) do |tip, idx|
+        idx[tip.game_id] << tip.user_id
+      end
+    end
+
+    def get_ordered_user_id_and_ranking_comparison_value(cum_8, cum_5, cum_4, cum_3, used_game_ids)
       user_id_and_sum_tip_points = TipQueries.sum_tip_points_group_by_user_id_by_game_ids(used_game_ids)
 
       user_id_and_ranking_comparison_value = user_id_and_sum_tip_points.map { |user_id, sum_tip_points|
-        count_8points = all_8point_tips.select { |tip| used_game_ids.include?(tip.game_id) && tip.user_id == user_id }.size
-        count_5points = all_5point_tips.select { |tip| used_game_ids.include?(tip.game_id) && tip.user_id == user_id }.size
-        count_4points = all_4point_tips.select { |tip| used_game_ids.include?(tip.game_id) && tip.user_id == user_id }.size
-        count_3points = all_3point_tips.select { |tip| used_game_ids.include?(tip.game_id) && tip.user_id == user_id }.size
-
-        [user_id, ranking_comparison_value(sum_tip_points, count_8points, count_5points, count_4points, count_3points).to_i]
+        [user_id, ranking_comparison_value(sum_tip_points, cum_8[user_id], cum_5[user_id], cum_4[user_id], cum_3[user_id]).to_i]
       }
 
-      ordered_user_id_and_ranking_comparison_value = user_id_and_ranking_comparison_value.sort_by { |_, tip_points| tip_points }.reverse
+      user_id_and_ranking_comparison_value.sort_by { |_, tip_points| tip_points }.reverse
     end
 
     def mass_updating_tips(result_for_this_game, tips_for_game)

--- a/app/views/admin/bonus_settings/new.html.haml
+++ b/app/views/admin/bonus_settings/new.html.haml
@@ -1,34 +1,34 @@
 .row
   .small-12.large-6.columns
-    %h3 Bonusantworten speichern
+    %h3= t('bonus_settings_heading')
 
     %p
-      Von den 4 Bonusfragen werden
-      %strong 2 automatisch ermittelt
-      (Turniersieger &amp; zweiter Platz) — diese werden direkt aus dem Finalspiel berechnet und müssen hier nicht eingetragen werden.
+      = t('bonus_settings_auto_calculated_intro')
+      %strong= t('bonus_settings_auto_calculated_count')
+      = t('bonus_settings_auto_calculated_detail')
     %p
-      Die folgenden
-      %strong 2 Fragen
-      können nicht automatisch ermittelt werden und müssen manuell eingetragen werden:
+      = t('bonus_settings_manual_intro')
+      %strong= t('bonus_settings_manual_count')
+      = t('bonus_settings_manual_detail')
 
     %ol
       %li
-        %strong 3. Wann fiel das erste Tor im Finale?
+        %strong= t('bonus_settings_question3_label')
       %li
-        %strong 4. Wie viele Tore erzielte der Torschützenkönig?
+        %strong= t('bonus_settings_question4_label')
 
     = form_tag admin_bonus_settings_path, method: :post do
       .row
         .small-12.columns
           %label
-            3. Wann fiel das erste Tor im Finale?
+            = t('bonus_settings_question3_label')
             - options = @when_first_goal_options.map { |k, v| [I18n.t("bonus_questions.when_final_first_goal_options.#{v}"), k] }
-            = select_tag 'bonus_when_final_first_goal', options_for_select(options, @bonus_when_first_goal), prompt: '– bitte wählen –'
+            = select_tag 'bonus_when_final_first_goal', options_for_select(options, @bonus_when_first_goal), prompt: t('bonus_settings_select_prompt')
       .row
         .small-12.columns
           %label
-            4. Wie viele Tore erzielte der Torschützenkönig?
-            = number_field_tag 'bonus_how_many_goals', @bonus_how_many_goals, min: 1, max: 99, size: 4, inputmode: 'numeric', placeholder: 'z.B. 8'
+            = t('bonus_settings_question4_label')
+            = number_field_tag 'bonus_how_many_goals', @bonus_how_many_goals, min: 1, max: 99, size: 4, inputmode: 'numeric', placeholder: t('bonus_settings_goals_placeholder')
       .row
         .small-12.columns
-          = submit_tag 'Bonusantworten speichern', class: 'button'
+          = submit_tag t('bonus_settings_submit'), class: 'button'

--- a/app/views/admin/games/index.html.haml
+++ b/app/views/admin/games/index.html.haml
@@ -1,9 +1,9 @@
 .row
   .small-12.columns
     %p
-      Erneute Berechnung aller Tips aller beendeten Spiele, aller Nutzerpunkte und der Statistik.
+      = t('admin_recalculate_description')
     = link_to(I18n.t(:start_calculating), new_admin_start_calculating_path, class: 'button')
-    = link_to('Bonusantworten verwalten', new_admin_bonus_settings_path, class: 'button secondary')
+    = link_to(t('admin_manage_bonus_settings'), new_admin_bonus_settings_path, class: 'button secondary')
 
     %h3=I18n.t('games_of', tournament_name: I18n.t('tournament_name'))
 

--- a/app/views/bonus/_bonus_tips.html.haml
+++ b/app/views/bonus/_bonus_tips.html.haml
@@ -1,4 +1,4 @@
-= I18n.t('bonus_question_help', round_name: presenter.round_of_16_name, extra_points: Users::UpdatePoints::BONUS_TIP_POINTS)
+= I18n.t('bonus_question_help', round_name: presenter.round_of_16_name, extra_points: TipPoints::BONUS)
 %br
 %br
 - if Tournament.round_of_16_not_yet_started?

--- a/app/views/compare_tips/show.html.haml
+++ b/app/views/compare_tips/show.html.haml
@@ -3,7 +3,7 @@
     %h3= t('comparetips')
 
     %p
-      Was haben die anderen getippt? Sobald ein Spiel begonnen hat, kannst du es hier erfahren.
+      = t('compare_tips_intro')
 
     - game_to_compare_presenter = @presenter.game_to_compare_presenter
     - tips = @presenter.tips

--- a/app/views/helps/show.de.html.haml
+++ b/app/views/helps/show.de.html.haml
@@ -17,67 +17,67 @@
       %b
         Mögliche Punkte pro Tipp
       %br
-      Pro Spiel gibt es maximal #{Tips::UpdatePoints::MAX_POINTS_PRO_TIP} Punkte!
+      Pro Spiel gibt es maximal #{TipPoints::PERFECT} Punkte!
       Es gilt immer das offiziell festgelegte Endergebnis inkl. Verlängerung und Elfmeterschießen.
     %ul.hilfe.no-bullet
       %li
         %p
-          - 8.times do
+          - TipPoints::PERFECT.times do
             = icon('far', 'circle', '', class: 'null-point-color')
           %br
-          0 Punkte: alles falsch
+          #{TipPoints::NO_POINTS} Punkte: alles falsch
       %li
         %p
-          - 3.times do
+          - TipPoints::CORRECT_TREND.times do
             = icon('fas', 'circle', '', class: 'three-point-color')
-          - 5.times do
+          - (TipPoints::PERFECT - TipPoints::CORRECT_TREND).times do
             = icon('far', 'circle', '', class: 'null-point-color')
           %br
-          #{Tips::UpdatePoints::POINTS_CORRECT_TREND} Punkte gibt es für den richtigen Tipp auf Sieg, Unentschieden oder Niederlage
+          #{TipPoints::CORRECT_TREND} Punkte gibt es für den richtigen Tipp auf Sieg, Unentschieden oder Niederlage
           %br
             (Spieltendenz richtig, aber nicht Tordifferenz oder eine Toranzahl der beiden Teams)
       %li
         %p
-          - 4.times do
+          - TipPoints::CORRECT_GOALS.times do
             = icon('fas', 'circle', '', class: 'four-point-color')
-          - 4.times do
+          - (TipPoints::PERFECT - TipPoints::CORRECT_GOALS).times do
             = icon('far', 'circle', '', class: 'null-point-color')
           %br
-          #{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT} Punkte:
+          #{TipPoints::CORRECT_GOALS} Punkte:
           %br
             (Spieltendenz richtig und die Tordifferenz)
       %li
         %p
-          - 5.times do
+          - TipPoints::CORRECT_GOALS_ONE_TEAM.times do
             = icon('fas', 'circle', '', class: 'five-point-color')
-          - 3.times do
+          - (TipPoints::PERFECT - TipPoints::CORRECT_GOALS_ONE_TEAM).times do
             = icon('far', 'circle', '', class: 'null-point-color')
           %br
-          #{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT_GOALS} Punkte: Spieltendenz richtig und eine Toranzahl eines Teams
+          #{TipPoints::CORRECT_GOALS_ONE_TEAM} Punkte: Spieltendenz richtig und eine Toranzahl eines Teams
       %li
         %p
-          - 8.times do
+          - TipPoints::PERFECT.times do
             = icon('fas', 'circle', '', class: 'eight-point-color')
           %br
-          #{Tips::UpdatePoints::MAX_POINTS_PRO_TIP} Punkte: Spieltendenz richtig und bei beiden Teams die korrekte Toranzahl, dadurch auch die Tordifferenz richtig
+          #{TipPoints::PERFECT} Punkte: Spieltendenz richtig und bei beiden Teams die korrekte Toranzahl, dadurch auch die Tordifferenz richtig
 
     %blockquote
       .label
         Beispiele
       %br
-      Wenn Frankreich gegen die Schweiz 3:0 spielt und du 3:1 getippt hast, erhältst du #{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT_GOALS} Punkte:
+      Wenn Frankreich gegen die Schweiz 3:0 spielt und du 3:1 getippt hast, erhältst du #{TipPoints::CORRECT_GOALS_ONE_TEAM} Punkte:
       %br
-      #{Tips::UpdatePoints::POINTS_CORRECT_TREND} Punkte für die richtige Tendenz und #{Tips::UpdatePoints::EXTRA_POINT_GOALS} Punkte für die korrekte Anzahl der französischen Tore.
+      #{TipPoints::CORRECT_TREND} Punkte für die richtige Tendenz und #{Tips::UpdatePoints::EXTRA_POINT_GOALS} Punkte für die korrekte Anzahl der französischen Tore.
       %br
       %br
       Wenn Deutschland gegen Italien 1:0 spielt und du 2:1 getippt hast,
-      erhältst du insgesamt #{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT} Punkte:
+      erhältst du insgesamt #{TipPoints::CORRECT_GOALS} Punkte:
       %br
-      #{Tips::UpdatePoints::POINTS_CORRECT_TREND} Punkte für die richtige Tendenz und #{Tips::UpdatePoints::EXTRA_POINT} Punkt für die korrekte Tordifferenz.
+      #{TipPoints::CORRECT_TREND} Punkte für die richtige Tendenz und #{Tips::UpdatePoints::EXTRA_POINT} Punkt für die korrekte Tordifferenz.
 
     %h4 Bonusfragen beantworten
     %p
-      = I18n.t('bonus_question_help', round_name: @presenter.round_of_16_name, extra_points: Users::UpdatePoints::BONUS_TIP_POINTS)
+      = I18n.t('bonus_question_help', round_name: @presenter.round_of_16_name, extra_points: TipPoints::BONUS)
 
     %blockquote
       - @presenter.bonus_questions.each do |question|
@@ -86,9 +86,9 @@
 
     %p
       Bei Punktgleichheit entscheidet die Anzahl der erreichten Tipppunkte über die Platzierung.
-      Wer mehr "#{Tips::UpdatePoints::MAX_POINTS_PRO_TIP} Punktetipps" hat, liegt vorn.
-      Bei gleicher Anzahl folgen die "#{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT_GOALS} Punktetipps".
-      Falls auch hier Gleichstand herrscht, entscheiden die "#{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT} Punktetipps" und so weiter.
+      Wer mehr "#{TipPoints::PERFECT} Punktetipps" hat, liegt vorn.
+      Bei gleicher Anzahl folgen die "#{TipPoints::CORRECT_GOALS_ONE_TEAM} Punktetipps".
+      Falls auch hier Gleichstand herrscht, entscheiden die "#{TipPoints::CORRECT_GOALS} Punktetipps" und so weiter.
 
     .row
       .small-12.medium-7.columns

--- a/app/views/helps/show.en.html.haml
+++ b/app/views/helps/show.en.html.haml
@@ -17,67 +17,67 @@
       %b
         Points per prediction
       %br
-      A maximum of #{Tips::UpdatePoints::MAX_POINTS_PRO_TIP} points per match!
+      A maximum of #{TipPoints::PERFECT} points per match!
       The officially determined final result applies, including extra time and penalty shoot-outs.
     %ul.hilfe.no-bullet
       %li
         %p
-          - 8.times do
+          - TipPoints::PERFECT.times do
             = icon('far', 'circle', '', class: 'null-point-color')
           %br
-          0 points: everything wrong
+          #{TipPoints::NO_POINTS} points: everything wrong
       %li
         %p
-          - 3.times do
+          - TipPoints::CORRECT_TREND.times do
             = icon('fas', 'circle', '', class: 'three-point-color')
-          - 5.times do
+          - (TipPoints::PERFECT - TipPoints::CORRECT_TREND).times do
             = icon('far', 'circle', '', class: 'null-point-color')
           %br
-          #{Tips::UpdatePoints::POINTS_CORRECT_TREND} points for predicting the correct outcome (win, draw, or loss)
+          #{TipPoints::CORRECT_TREND} points for predicting the correct outcome (win, draw, or loss)
           %br
             (correct tendency, but wrong goal difference or goal count for one or both teams)
       %li
         %p
-          - 4.times do
+          - TipPoints::CORRECT_GOALS.times do
             = icon('fas', 'circle', '', class: 'four-point-color')
-          - 4.times do
+          - (TipPoints::PERFECT - TipPoints::CORRECT_GOALS).times do
             = icon('far', 'circle', '', class: 'null-point-color')
           %br
-          #{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT} points:
+          #{TipPoints::CORRECT_GOALS} points:
           %br
             (correct tendency and correct goal difference)
       %li
         %p
-          - 5.times do
+          - TipPoints::CORRECT_GOALS_ONE_TEAM.times do
             = icon('fas', 'circle', '', class: 'five-point-color')
-          - 3.times do
+          - (TipPoints::PERFECT - TipPoints::CORRECT_GOALS_ONE_TEAM).times do
             = icon('far', 'circle', '', class: 'null-point-color')
           %br
-          #{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT_GOALS} points: correct tendency and correct goal count for one team
+          #{TipPoints::CORRECT_GOALS_ONE_TEAM} points: correct tendency and correct goal count for one team
       %li
         %p
-          - 8.times do
+          - TipPoints::PERFECT.times do
             = icon('fas', 'circle', '', class: 'eight-point-color')
           %br
-          #{Tips::UpdatePoints::MAX_POINTS_PRO_TIP} points: correct tendency and correct goal count for both teams (which also means correct goal difference)
+          #{TipPoints::PERFECT} points: correct tendency and correct goal count for both teams (which also means correct goal difference)
 
     %blockquote
       .label
         Examples
       %br
-      If France beats Switzerland 3:0 and you predicted 3:1, you get #{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT_GOALS} points:
+      If France beats Switzerland 3:0 and you predicted 3:1, you get #{TipPoints::CORRECT_GOALS_ONE_TEAM} points:
       %br
-      #{Tips::UpdatePoints::POINTS_CORRECT_TREND} points for the correct tendency and #{Tips::UpdatePoints::EXTRA_POINT_GOALS} points for France's correct goal count.
+      #{TipPoints::CORRECT_TREND} points for the correct tendency and #{Tips::UpdatePoints::EXTRA_POINT_GOALS} points for France's correct goal count.
       %br
       %br
       If Germany beats Italy 1:0 and you predicted 2:1,
-      you get #{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT} points in total:
+      you get #{TipPoints::CORRECT_GOALS} points in total:
       %br
-      #{Tips::UpdatePoints::POINTS_CORRECT_TREND} points for the correct tendency and #{Tips::UpdatePoints::EXTRA_POINT} point for the correct goal difference.
+      #{TipPoints::CORRECT_TREND} points for the correct tendency and #{Tips::UpdatePoints::EXTRA_POINT} point for the correct goal difference.
 
     %h4 Bonus questions
     %p
-      = I18n.t('bonus_question_help', round_name: @presenter.round_of_16_name, extra_points: Users::UpdatePoints::BONUS_TIP_POINTS)
+      = I18n.t('bonus_question_help', round_name: @presenter.round_of_16_name, extra_points: TipPoints::BONUS)
 
     %blockquote
       - @presenter.bonus_questions.each do |question|
@@ -85,9 +85,9 @@
         %br
 
     %p
-      In the event of a tie on points, the number of #{Tips::UpdatePoints::MAX_POINTS_PRO_TIP}-point predictions decides the ranking.
-      If still tied, #{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT_GOALS}-point predictions decide,
-      then #{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT}-point predictions, and so on.
+      In the event of a tie on points, the number of #{TipPoints::PERFECT}-point predictions decides the ranking.
+      If still tied, #{TipPoints::CORRECT_GOALS_ONE_TEAM}-point predictions decide,
+      then #{TipPoints::CORRECT_GOALS}-point predictions, and so on.
 
     .row
       .small-12.medium-7.columns

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -6,9 +6,9 @@
 %title= get_title
 %meta{name: 'author', content: 'Soeren Mothes'}
 %meta{name: 'title', content: get_title}
-- description = 'Fußball-Tippspiel auf soemo.org. Dem Sieger winkt ein Wanderpokal verbunden mit unbeschreiblichem Ruhm und uneingeschränktem Prahlrecht.'
+- description = I18n.t('meta_description')
 %meta{name: 'description', content: description}
-%meta{name: 'keywords', content: 'fussball tippspiel soemo, soeren mothes'}
+%meta{name: 'keywords', content: I18n.t('meta_keywords')}
 
 %meta{property: 'og:title', content: get_title}
 %meta{property: 'og:description', content: description}

--- a/app/views/main/_user_tips.html.haml
+++ b/app/views/main/_user_tips.html.haml
@@ -57,7 +57,7 @@
             %td.hide-for-small-only
               = game_presenter.formatted_start_at
               %span.place-info
-                = 'in'
+                = t('place_in')
                 = place
             %td.hide-for-small-only
               = game_presenter.round_or_group_name

--- a/app/views/main/index.html.haml
+++ b/app/views/main/index.html.haml
@@ -24,10 +24,9 @@
             %br
             %p
               %b
-                AUUUSSS AUUUSSS - das Spiel ist aus!
+                = t('tournament_finished_heading')
             %p
-              Der Pokal wird schnellstmöglich dem Gewinner überreicht.
-              Vielen Dank für die rege Teilnahme und den gemeinsamen Spaß. Bis bald zum nächsten Mal!
+              = t('tournament_finished_body')
 
     -# Space placeholder
     .row.show-for-small-only

--- a/app/views/notes/index.html.haml
+++ b/app/views/notes/index.html.haml
@@ -6,7 +6,7 @@
       .row
         .small-12.columns
           %label
-            ="Na haste was zu melden?"
+            = t("notice_label")
             = text_area_tag :text, nil, :id=>"notice_text", :class=>"span7",:maxlength => 200,:rows => 3
             %div
               = I18n.t("characters_remaining")

--- a/app/views/rankings/index.html.haml
+++ b/app/views/rankings/index.html.haml
@@ -12,19 +12,19 @@
       %small
         %span.point-explaining
           = icon('fas', 'circle', '', class: 'eight-point-color')
-          = "#{Tips::UpdatePoints::MAX_POINTS_PRO_TIP} Pkt."
+          = "#{TipPoints::PERFECT} Pkt."
         %span.point-explaining
           = icon('fas', 'circle', '', class: 'five-point-color')
-          = "#{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT_GOALS} Pkt."
+          = "#{TipPoints::CORRECT_GOALS_ONE_TEAM} Pkt."
         %span.point-explaining
           = icon('fas', 'circle', '', class: 'four-point-color')
-          = "#{Tips::UpdatePoints::POINTS_CORRECT_TREND + Tips::UpdatePoints::EXTRA_POINT} Pkt."
+          = "#{TipPoints::CORRECT_GOALS} Pkt."
         %span.point-explaining
           = icon('fas', 'circle', '', class: 'three-point-color')
-          = "#{Tips::UpdatePoints::POINTS_CORRECT_TREND} Pkt."
+          = "#{TipPoints::CORRECT_TREND} Pkt."
         %span.point-explaining
           = icon('fas', 'circle', '', class: 'null-point-color')
-          = '0 Pkt.'
+          = "#{TipPoints::NO_POINTS} Pkt."
         %span.point-explaining
           = icon('fas', 'circle', '', class: 'badge-bonus bonus-point-color')
           = User.human_attribute_name('bonuspoints_small')

--- a/app/views/rankings/index.html.haml
+++ b/app/views/rankings/index.html.haml
@@ -12,19 +12,19 @@
       %small
         %span.point-explaining
           = icon('fas', 'circle', '', class: 'eight-point-color')
-          = "#{TipPoints::PERFECT} Pkt."
+          = "#{TipPoints::PERFECT} #{t('points_abbr')}"
         %span.point-explaining
           = icon('fas', 'circle', '', class: 'five-point-color')
-          = "#{TipPoints::CORRECT_GOALS_ONE_TEAM} Pkt."
+          = "#{TipPoints::CORRECT_GOALS_ONE_TEAM} #{t('points_abbr')}"
         %span.point-explaining
           = icon('fas', 'circle', '', class: 'four-point-color')
-          = "#{TipPoints::CORRECT_GOALS} Pkt."
+          = "#{TipPoints::CORRECT_GOALS} #{t('points_abbr')}"
         %span.point-explaining
           = icon('fas', 'circle', '', class: 'three-point-color')
-          = "#{TipPoints::CORRECT_TREND} Pkt."
+          = "#{TipPoints::CORRECT_TREND} #{t('points_abbr')}"
         %span.point-explaining
           = icon('fas', 'circle', '', class: 'null-point-color')
-          = "#{TipPoints::NO_POINTS} Pkt."
+          = "#{TipPoints::NO_POINTS} #{t('points_abbr')}"
         %span.point-explaining
           = icon('fas', 'circle', '', class: 'badge-bonus bonus-point-color')
           = User.human_attribute_name('bonuspoints_small')

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -28,6 +28,33 @@ de:
   notice_needs_spaces: "Bitte einen vernünftigen Beitrag angeben."
   notice_label: "Na haste was zu melden?"
 
+  points_abbr: "Pkt."
+  place_in: "in"
+
+  meta_description: "Fußball-Tippspiel auf soemo.org. Dem Sieger winkt ein Wanderpokal verbunden mit unbeschreiblichem Ruhm und uneingeschränktem Prahlrecht."
+  meta_keywords: "fussball tippspiel soemo, soeren mothes"
+
+  tournament_finished_heading: "AUUUSSS AUUUSSS - das Spiel ist aus!"
+  tournament_finished_body: "Der Pokal wird schnellstmöglich dem Gewinner überreicht. Vielen Dank für die rege Teilnahme und den gemeinsamen Spaß. Bis bald zum nächsten Mal!"
+
+  compare_tips_intro: "Was haben die anderen getippt? Sobald ein Spiel begonnen hat, kannst du es hier erfahren."
+
+  admin_recalculate_description: "Erneute Berechnung aller Tips aller beendeten Spiele, aller Nutzerpunkte und der Statistik."
+  admin_manage_bonus_settings: "Bonusantworten verwalten"
+
+  bonus_settings_heading: "Bonusantworten speichern"
+  bonus_settings_auto_calculated_intro: "Von den 4 Bonusfragen werden"
+  bonus_settings_auto_calculated_count: "2 automatisch ermittelt"
+  bonus_settings_auto_calculated_detail: "(Turniersieger & zweiter Platz) — diese werden direkt aus dem Finalspiel berechnet und müssen hier nicht eingetragen werden."
+  bonus_settings_manual_intro: "Die folgenden"
+  bonus_settings_manual_count: "2 Fragen"
+  bonus_settings_manual_detail: "können nicht automatisch ermittelt werden und müssen manuell eingetragen werden:"
+  bonus_settings_question3_label: "3. Wann fiel das erste Tor im Finale?"
+  bonus_settings_question4_label: "4. Wie viele Tore erzielte der Torschützenkönig?"
+  bonus_settings_select_prompt: "– bitte wählen –"
+  bonus_settings_goals_placeholder: "z.B. 8"
+  bonus_settings_submit: "Bonusantworten speichern"
+
   update_successful: "%{object_name} wurde aktualisiert."
   type_to_filter: Tippen um zu Filtern
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -26,6 +26,7 @@ de:
   create_successful: "%{object_name} wurde erfolgreich angelegt"
   notice_needs_a_comment: "Bitte keine Null Nummer angeben."
   notice_needs_spaces: "Bitte einen vernünftigen Beitrag angeben."
+  notice_label: "Na haste was zu melden?"
 
   update_successful: "%{object_name} wurde aktualisiert."
   type_to_filter: Tippen um zu Filtern

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
   update_successful: "%{object_name} was updated."
   notice_needs_a_comment: "Please do not enter a zero."
   notice_needs_spaces: "Please enter a reasonable comment."
+  notice_label: "Got something to say?"
   succesfully_saved_tips: "Your tips have been saved!"
   succesfully_saved_bonustip: "Your bonus tips have been saved successfully."
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,33 @@ en:
   notice_needs_a_comment: "Please do not enter a zero."
   notice_needs_spaces: "Please enter a reasonable comment."
   notice_label: "Got something to say?"
+
+  points_abbr: "pts."
+  place_in: "in"
+
+  meta_description: "Football prediction game on soemo.org. The winner takes home a coveted trophy along with boundless glory and unlimited bragging rights."
+  meta_keywords: "football prediction game soemo, soeren mothes"
+
+  tournament_finished_heading: "FULL TIME - the game is over!"
+  tournament_finished_body: "The trophy will be presented to the winner as soon as possible. Thank you for taking part and for the fun we had together. See you next time!"
+
+  compare_tips_intro: "What did the others predict? Once a match has kicked off, you can find out here."
+
+  admin_recalculate_description: "Recalculate all tips for all finished games, all user points and statistics."
+  admin_manage_bonus_settings: "Manage bonus answers"
+
+  bonus_settings_heading: "Save bonus answers"
+  bonus_settings_auto_calculated_intro: "Of the 4 bonus questions,"
+  bonus_settings_auto_calculated_count: "2 are determined automatically"
+  bonus_settings_auto_calculated_detail: "(tournament winner & runner-up) — these are calculated directly from the final match and do not need to be entered here."
+  bonus_settings_manual_intro: "The following"
+  bonus_settings_manual_count: "2 questions"
+  bonus_settings_manual_detail: "cannot be determined automatically and must be entered manually:"
+  bonus_settings_question3_label: "3. When was the first goal scored in the final?"
+  bonus_settings_question4_label: "4. How many goals did the top scorer score?"
+  bonus_settings_select_prompt: "– please select –"
+  bonus_settings_goals_placeholder: "e.g. 8"
+  bonus_settings_submit: "Save bonus answers"
   succesfully_saved_tips: "Your tips have been saved!"
   succesfully_saved_bonustip: "Your bonus tips have been saved successfully."
 

--- a/db/migrate/20260516102214_add_index_to_tips_user_id_and_tip_points.rb
+++ b/db/migrate/20260516102214_add_index_to_tips_user_id_and_tip_points.rb
@@ -1,0 +1,5 @@
+class AddIndexToTipsUserIdAndTipPoints < ActiveRecord::Migration[6.1]
+  def change
+    add_index :tips, [:user_id, :tip_points], name: 'index_tips_on_user_id_and_tip_points'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_05_16_000000) do
+ActiveRecord::Schema.define(version: 2026_05_16_102214) do
 
   create_table "app_settings", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 2026_05_16_000000) do
     t.integer "lock_version", default: 0
     t.integer "ranking_place"
     t.index ["game_id"], name: "index_tips_on_game_id"
+    t.index ["user_id", "tip_points"], name: "index_tips_on_user_id_and_tip_points"
     t.index ["user_id"], name: "index_tips_on_user_id"
   end
 


### PR DESCRIPTION
## Summary

- **Performance: N×6 queries → 2 bulk queries** in `Users::UpdatePoints` — replaced per-user `SUM` and 5 `COUNT` calls with two `GROUP BY` aggregate queries executed once before the loop. With 50 users this cuts 300 queries down to 2.
- **Performance: O(N×G×tips) → O(tips + games×users)** in `UpdateRankingPerGame` — replaced `.select` array scans inside the game loop with pre-built `{ game_id => [user_id] }` index hashes and cumulative per-user counters updated incrementally per game.
- **New DB index** on `tips(user_id, tip_points)` to back the new `GROUP BY user_id, tip_points` query and the existing point-tier lookups.
- **`TipPoints` module** as single source of truth for all tip and bonus point values (`PERFECT`, `CORRECT_GOALS_ONE_TEAM`, `CORRECT_GOALS`, `CORRECT_TREND`, `NO_POINTS`, `BONUS`); replaces scattered literals and `Tips::UpdatePoints` arithmetic expressions across services, helpers, and views.

## Changed files

- `app/models/tip_points.rb` *(new)*
- `db/migrate/20260516102214_add_index_to_tips_user_id_and_tip_points.rb` *(new)*
- `app/models/tips/tip_queries.rb` — two new bulk query methods
- `app/services/users/update_points.rb` — bulk query refactor + `TipPoints` constants
- `app/services/users/update_ranking_per_game.rb` — index hash refactor + `TipPoints` constants
- `app/services/tips/update_points.rb` — `TipPoints` constants
- `app/helpers/application_helper.rb` — `TipPoints::BONUS`
- `app/views/helps/show.de.html.haml` — `TipPoints` constants, dynamic `.times` loops
- `app/views/helps/show.en.html.haml` — same
- `app/views/rankings/index.html.haml` — `TipPoints` constants
- `app/views/bonus/_bonus_tips.html.haml` — `TipPoints::BONUS`

## Tests

All 397 existing examples pass. No test changes were made.