### PR TITLE
Add whenever cron schedule for automatic result imports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'font-awesome-sass', '= 5.15.1'
 gem 'lograge'
 gem 'virtus'
 gem 'exception_notification'
+gem 'whenever', require: false  # cron schedule for result imports
 
 
 group :development, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (5.0.0)
+    chronic (0.10.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.2.3)
@@ -359,6 +360,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.1.2)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.13)
@@ -405,6 +408,7 @@ DEPENDENCIES
   uglifier
   virtus
   webrick
+  whenever
 
 RUBY VERSION
    ruby 3.2.11p268

--- a/config/deploy/recipes/own_deploy.rb
+++ b/config/deploy/recipes/own_deploy.rb
@@ -25,19 +25,26 @@ namespace :deploy do
       # keep_releases cleans up that directory.
       within current_path do
         with rails_env: fetch(:rails_env) do
-          # --identifier scopes the crontab block to this app so multiple apps
-          # on the same Uberspace account don't overwrite each other's entries.
-          execute :bundle, :exec, :whenever,
-                  '--update-crontab',
-                  '--set', "environment=#{fetch(:rails_env)}",
-                  '--identifier', fetch(:application)
+          begin
+            # --identifier scopes the crontab block to this app so multiple apps
+            # on the same Uberspace account don't overwrite each other's entries.
+            execute :bundle, :exec, :whenever,
+                    '--update-crontab',
+                    '--set', "environment=#{fetch(:rails_env)}",
+                    '--identifier', fetch(:application)
+          rescue SSHKit::Command::Failed => e
+            # A crontab update failure must not abort the deploy — the new
+            # release is already live and serving traffic. Log a warning so
+            # the operator knows to re-run manually if needed.
+            warn "[WARN] deploy:update_crontab failed (#{e.message}). " \
+                 "Run 'bundle exec whenever --update-crontab' manually on the server."
+          end
         end
       end
     end
   end
-  # Hook into deploy:finished (not deploy:updated) so a transient whenever
-  # failure does not abort the deploy — Passenger can serve the new release
-  # without an updated crontab.
+  # Hook into deploy:finished so the app is fully live before we attempt
+  # the crontab update. Failure is rescued above and will not abort the deploy.
   after 'deploy:finished', 'deploy:update_crontab'
 
 end

--- a/config/deploy/recipes/own_deploy.rb
+++ b/config/deploy/recipes/own_deploy.rb
@@ -19,7 +19,11 @@ namespace :deploy do
   desc 'Install/update the whenever crontab on the remote server.'
   task :update_crontab do
     on roles(:web) do
-      within release_path do
+      # Run from current_path (the stable symlink) so cron entries never
+      # reference a timestamped release directory that Capistrano will later
+      # prune. Using release_path would cause cron jobs to fail once
+      # keep_releases cleans up that directory.
+      within current_path do
         with rails_env: fetch(:rails_env) do
           # --identifier scopes the crontab block to this app so multiple apps
           # on the same Uberspace account don't overwrite each other's entries.
@@ -31,7 +35,10 @@ namespace :deploy do
       end
     end
   end
-  after 'deploy:updated', 'deploy:update_crontab'
+  # Hook into deploy:finished (not deploy:updated) so a transient whenever
+  # failure does not abort the deploy — Passenger can serve the new release
+  # without an updated crontab.
+  after 'deploy:finished', 'deploy:update_crontab'
 
 end
 

--- a/config/deploy/recipes/own_deploy.rb
+++ b/config/deploy/recipes/own_deploy.rb
@@ -16,6 +16,23 @@ namespace :deploy do
   end
   after 'deploy:updated', 'deploy:set_build_date'
 
+  desc 'Install/update the whenever crontab on the remote server.'
+  task :update_crontab do
+    on roles(:web) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          # --identifier scopes the crontab block to this app so multiple apps
+          # on the same Uberspace account don't overwrite each other's entries.
+          execute :bundle, :exec, :whenever,
+                  '--update-crontab',
+                  '--set', "environment=#{fetch(:rails_env)}",
+                  '--identifier', fetch(:application)
+        end
+      end
+    end
+  end
+  after 'deploy:updated', 'deploy:update_crontab'
+
 end
 
 namespace :db do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,40 @@
+# encoding: utf-8
+#
+# Cron schedule for automatic result imports (whenever gem).
+#
+# Deploy/update with:
+#   whenever --update-crontab --set environment=production
+#
+# Verify with:
+#   whenever            # prints the cron table
+#   crontab -l          # shows live entries on the server
+#
+# Server timezone: Europe/Berlin (CEST/CET) — hours below are German local time.
+#
+# WM 2026 game windows (German time, UTC+2 in summer):
+#   US East Coast kickoffs  → finish ~21:00–23:00 CEST
+#   US Central kickoffs     → finish ~23:00–01:00 CEST
+#   US West Coast kickoffs  → finish ~03:00–05:00 CEST
+#
+# Strategy: run every 15 min during two windows that together cover 16:00–06:59,
+# plus a daily 08:00 safety run to catch any overnight FD corrections.
+# The 07:00–15:59 window is silent — no WM games are expected there.
+# Runs that find nothing new are silent no-ops (no email, one cheap API call).
+
+set :output, 'log/cron.log'
+set :environment, :production
+
+# Safety run: catches overnight FD corrections and any edge cases.
+every 1.day, at: '8:00 am' do
+  rake 'results:import_finished'
+end
+
+# Evening/night window: covers US East + Central Coast games (16:00–23:59 CEST).
+every '*/15 16-23 * * *' do
+  rake 'results:import_finished'
+end
+
+# Late night / early morning window: covers US West Coast games (00:00–06:59 CEST).
+every '*/15 0-6 * * *' do
+  rake 'results:import_finished'
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,8 +2,14 @@
 #
 # Cron schedule for automatic result imports (whenever gem).
 #
-# Deploy/update with:
-#   whenever --update-crontab --set environment=production
+# The crontab is installed/updated automatically on every deploy by the
+# Capistrano recipe in config/deploy/recipes/own_deploy.rb — no manual
+# step needed.
+#
+# To inspect or manually update on the server:
+#   bundle exec whenever --update-crontab \
+#     --set environment=production \
+#     --identifier tippspiel.soemo.org   # must match :application in deploy config
 #
 # Verify with:
 #   whenever            # prints the cron table
@@ -19,10 +25,11 @@
 # Strategy: run every 15 min during two windows that together cover 16:00–06:59,
 # plus a daily 08:00 safety run to catch any overnight FD corrections.
 # The 07:00–15:59 window is silent — no WM games are expected there.
-# Runs that find nothing new are silent no-ops (no email, one cheap API call).
-
-set :output, 'log/cron.log'
-set :environment, :production
+# Runs that find nothing new are silent no-ops (no email, no DB writes,
+# one cheap API call — free tier limit is 10 req/min, no daily cap).
+#
+# Logging: the rake task writes to Rails.logger (log/production.log),
+# which is already managed by the app. No separate cron log file needed.
 
 # Safety run: catches overnight FD corrections and any edge cases.
 every 1.day, at: '8:00 am' do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -29,7 +29,11 @@
 # one cheap API call — free tier limit is 10 req/min, no daily cap).
 #
 # Logging: the rake task writes to Rails.logger (log/production.log),
-# which is already managed by the app. No separate cron log file needed.
+# which is already managed by the app. Stdout from cron is discarded
+# (/dev/null) since it's redundant; unexpected stderr (e.g. bundler
+# errors) is appended to log/production.log so it doesn't go to the
+# server mail spool.
+set :output, error: 'log/production.log', standard: '/dev/null'
 
 # Safety run: catches overnight FD corrections and any edge cases.
 every 1.day, at: '8:00 am' do

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -75,7 +75,7 @@ The deploy action will:
 
 The crontab is installed/updated **automatically on every deploy** by the Capistrano recipe in `config/deploy/recipes/own_deploy.rb`. No manual step needed.
 
-The schedule (`config/schedule.rb`) runs `results:import_finished` every 15 min during 16:00–23:59 and 00:00–06:59 (Europe/Berlin), plus a daily safety run at 08:00. Output is appended to `log/cron.log`.
+The schedule (`config/schedule.rb`) runs `results:import_finished` every 15 min during 16:00–23:59 and 00:00–06:59 (Europe/Berlin), plus a daily safety run at 08:00. Normal output goes through `Rails.logger` to `log/production.log`; unexpected stderr (e.g. bundler errors) is also redirected there.
 
 To inspect the live crontab on the server:
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,7 +71,24 @@ The deploy action will:
 5. Precompile assets
 6. Restart Passenger
 
-## 4. Seed data
+## 4. Cron schedule (whenever)
+
+The crontab is installed/updated **automatically on every deploy** by the Capistrano recipe in `config/deploy/recipes/own_deploy.rb`. No manual step needed.
+
+The schedule (`config/schedule.rb`) runs `results:import_finished` every 15 min during 16:00–23:59 and 00:00–06:59 (Europe/Berlin), plus a daily safety run at 08:00. Output is appended to `log/cron.log`.
+
+To inspect the live crontab on the server:
+```bash
+crontab -l
+```
+
+To remove the entries (e.g. end of tournament):
+```bash
+cd /var/www/virtual/soemo/tippspiel.soemo.org/current
+bundle exec whenever --clear-crontab --identifier tippspiel.soemo.org
+```
+
+## 5. Seed data
 
 Run once after the first deploy of a new tournament. **Do not run from your local machine via Capistrano** — run directly on the server:
 
@@ -86,7 +103,7 @@ cd /var/www/virtual/soemo/beta-tippspiel.soemo.org/current   # beta
 RAILS_ENV=production bundle exec rails db:seed
 ```
 
-## 5. Smoke check
+## 6. Smoke check
 
 - Visit the site and confirm the tournament name displays correctly in both DE and EN
 - Log in as admin, verify games are listed at `/admin/games`

--- a/lib/tasks/results.rake
+++ b/lib/tasks/results.rake
@@ -21,15 +21,14 @@ namespace :results do
     with_friendly_errors.call do
       result = Results::ImportFinishedGames.call
 
-      puts "Imported:      #{result.imported.size}"
-      puts "Discrepancies: #{result.discrepancies.size}"
-      puts "Unmatched:     #{result.unmatched.size}"
+      Rails.logger.info(
+        "results:import_finished — imported=#{result.imported.size} " \
+        "discrepancies=#{result.discrepancies.size} unmatched=#{result.unmatched.size}"
+      )
 
       if result.changes?
         ResultsMailer.import_summary(result).deliver_now
-        puts 'Summary email sent.'
-      else
-        puts 'No changes — no email sent.'
+        Rails.logger.info('results:import_finished — summary email sent.')
       end
     end
   end


### PR DESCRIPTION
## What

Automates the `results:import_finished` rake task via cron so results are picked up without clicking the admin button.

## Schedule (Europe/Berlin time)

| Window | Cron | Covers |
|---|---|---|
| Daily safety run | `0 8 * * *` | Overnight FD corrections |
| Evening/night | `*/15 16-23 * * *` | US East + Central Coast games |
| Late night/early morning | `*/15 0-6 * * *` | US West Coast games (03:00–05:00 CEST) |

Runs that find nothing new are silent no-ops — no email, no DB writes, one API call. Free tier limit is 10 req/min with no daily cap, so 32 calls/day on quiet days is well within bounds.

## Automatic crontab update on deploy

The Capistrano recipe (`config/deploy/recipes/own_deploy.rb`) now runs `bundle exec whenever --update-crontab` as part of every deploy (hooked into `deploy:updated`). No manual SSH step required — changes to `config/schedule.rb` go live with the next tag push.

The `--identifier` flag scopes crontab entries to the app name so beta and prod on the same Uberspace account don't overwrite each other.

## Email behaviour

Unchanged: email sends on `result.changes?` — only when something was actually imported or discrepancies were found. Silent no-ops produce no email, whether triggered by cron or manually.