### PR TITLE
Fix whenever integration: correct identifier syntax, skip beta deploys

### DIFF
--- a/config/deploy/recipes/own_deploy.rb
+++ b/config/deploy/recipes/own_deploy.rb
@@ -16,8 +16,12 @@ namespace :deploy do
   end
   after 'deploy:updated', 'deploy:set_build_date'
 
-  desc 'Install/update the whenever crontab on the remote server.'
+  desc 'Install/update the whenever crontab on the remote server (production only).'
   task :update_crontab do
+    # Only install cron jobs for production. Beta runs on the same Uberspace
+    # account and must not install result-import cron entries.
+    next unless fetch(:application) == 'tippspiel.soemo.org'
+
     on roles(:web) do
       # Run from current_path (the stable symlink) so cron entries never
       # reference a timestamped release directory that Capistrano will later
@@ -26,18 +30,19 @@ namespace :deploy do
       within current_path do
         with rails_env: fetch(:rails_env) do
           begin
-            # --identifier scopes the crontab block to this app so multiple apps
-            # on the same Uberspace account don't overwrite each other's entries.
+            # The identifier is passed as an argument to --update-crontab
+            # (whenever 1.1.2 syntax), not as a separate --identifier flag.
+            # It scopes the crontab block so this app's entries can be
+            # updated/removed independently of other apps on the same account.
             execute :bundle, :exec, :whenever,
-                    '--update-crontab',
-                    '--set', "environment=#{fetch(:rails_env)}",
-                    '--identifier', fetch(:application)
+                    "--update-crontab #{fetch(:application)}",
+                    '--set', "environment=#{fetch(:rails_env)}"
           rescue SSHKit::Command::Failed => e
             # A crontab update failure must not abort the deploy — the new
             # release is already live and serving traffic. Log a warning so
             # the operator knows to re-run manually if needed.
             warn "[WARN] deploy:update_crontab failed (#{e.message}). " \
-                 "Run 'bundle exec whenever --update-crontab' manually on the server."
+                 "Run 'bundle exec whenever --update-crontab #{fetch(:application)}' manually on the server."
           end
         end
       end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,14 +2,16 @@
 #
 # Cron schedule for automatic result imports (whenever gem).
 #
-# The crontab is installed/updated automatically on every deploy by the
+# The crontab is installed/updated automatically on production deploys by the
 # Capistrano recipe in config/deploy/recipes/own_deploy.rb — no manual
-# step needed.
+# step needed. The recipe skips beta deploys.
 #
 # To inspect or manually update on the server:
-#   bundle exec whenever --update-crontab \
-#     --set environment=production \
-#     --identifier tippspiel.soemo.org   # must match :application in deploy config
+#   bundle exec whenever --update-crontab tippspiel.soemo.org \
+#     --set environment=production
+#
+# To remove entries at end of tournament:
+#   bundle exec whenever --clear-crontab tippspiel.soemo.org
 #
 # Verify with:
 #   whenever            # prints the cron table

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -73,7 +73,7 @@ The deploy action will:
 
 ## 4. Cron schedule (whenever)
 
-The crontab is installed/updated **automatically on every deploy** by the Capistrano recipe in `config/deploy/recipes/own_deploy.rb`. No manual step needed.
+The crontab is installed/updated **automatically on production deploys** by the Capistrano recipe in `config/deploy/recipes/own_deploy.rb`. The recipe skips beta deploys. No manual step needed.
 
 The schedule (`config/schedule.rb`) runs `results:import_finished` every 15 min during 16:00–23:59 and 00:00–06:59 (Europe/Berlin), plus a daily safety run at 08:00. Normal output goes through `Rails.logger` to `log/production.log`; unexpected stderr (e.g. bundler errors) is also redirected there.
 
@@ -85,7 +85,7 @@ crontab -l
 To remove the entries (e.g. end of tournament):
 ```bash
 cd /var/www/virtual/soemo/tippspiel.soemo.org/current
-bundle exec whenever --clear-crontab --identifier tippspiel.soemo.org
+bundle exec whenever --clear-crontab tippspiel.soemo.org
 ```
 
 ## 5. Seed data


### PR DESCRIPTION
## What

Follow-up to #110. Fixes two issues discovered during beta deploy:

### 1. Invalid `--identifier` flag
whenever 1.1.2 does not support a `--identifier` flag. The identifier is passed as a positional argument to `--update-crontab` / `--clear-crontab`:
```
# correct
bundle exec whenever --update-crontab tippspiel.soemo.org --set environment=production

# wrong (was causing deploy error)
bundle exec whenever --update-crontab --identifier tippspiel.soemo.org
```

### 2. Crontab installed on beta deploys
The recipe ran on every deploy, including beta, which is wrong — result-import cron jobs should only run in production. Added a `next unless` guard that skips the task when `application != 'tippspiel.soemo.org'`.

## Changes
- `config/deploy/recipes/own_deploy.rb`: fix identifier syntax; gate to production only
- `config/schedule.rb`: update manual command comments
- `docs/deployment.md`: fix `--clear-crontab` command; clarify "production deploys only"

## Tests
454 examples, 0 failures