### PR TITLE
Add English body to user-facing Devise emails

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -565,3 +565,18 @@
                                       Ich wünsche dir viel Spaß und Erfolg!
                                       %br/
                                       Sören "Harry" Mothes
+                                  %hr{:style => "border:0; border-top:1px solid #dddddd; margin:18px 0;"}/
+                                  %h1
+                                    %span{:style => "color:#AF1C1C"} Hello #{@resource.firstname},
+                                  %p{:style => "text-align: left; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;"}
+                                    %span{:style => "font-family:arial,helvetica neue,helvetica,sans-serif"}
+                                      please confirm your participation in the #{I18n.t(:tournament_name)} #{I18n.t(:app_name)} on soemo.org.
+                                      %br/
+                                      %br/
+                                      %a{:href => "#{confirmation_url(@resource, :confirmation_token => @token)}", :target => "_blank"}>
+                                        %span{:style => "color:#AF1C1C"} Confirm participation
+                                      %br/
+                                      %br/
+                                      I wish you lots of fun and success!
+                                      %br/
+                                      Sören "Harry" Mothes

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -570,7 +570,7 @@
                                     %span{:style => "color:#AF1C1C"} Hello #{@resource.firstname},
                                   %p{:style => "text-align: left; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;"}
                                     %span{:style => "font-family:arial,helvetica neue,helvetica,sans-serif"}
-                                      please confirm your participation in the #{I18n.t(:tournament_name)} #{I18n.t(:app_name)} on soemo.org.
+                                      please confirm your participation at the #{I18n.t(:tournament_name)} #{I18n.t(:app_name)} on soemo.org.
                                       %br/
                                       %br/
                                       %a{:href => "#{confirmation_url(@resource, :confirmation_token => @token)}", :target => "_blank"}>

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -555,7 +555,7 @@
                                     %span{:style => "color:#AF1C1C"} Hallo #{@resource.firstname},
                                   %p{:style => "text-align: left; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;"}
                                     %span{:style => "font-family:arial,helvetica neue,helvetica,sans-serif"}
-                                      mit dem unten angegeben Link kannst du dein Passwort zurücksetzen.
+                                      mit dem unten angegebenen Link kannst du dein Passwort zurücksetzen.
                                       %br/
                                       %br/
                                       Wenn du diese Anfrage nicht gestellt hast, ignoriere einfach diese Mail.

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -566,4 +566,20 @@
                                       %a{:href => "#{edit_password_url(@resource, :reset_password_token => @token)}", :target => "_blank"}>
                                         %span{:style => "color:#AF1C1C"} Passwort zurücksetzen
                                       %br/
+                                  %hr{:style => "border:0; border-top:1px solid #dddddd; margin:18px 0;"}/
+                                  %h1
+                                    %span{:style => "color:#AF1C1C"} Hello #{@resource.firstname},
+                                  %p{:style => "text-align: left; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;"}
+                                    %span{:style => "font-family:arial,helvetica neue,helvetica,sans-serif"}
+                                      you can reset your password using the link below.
+                                      %br/
+                                      %br/
+                                      If you did not request this, simply ignore this email.
+                                      %br/
+                                      Your password will not be changed until you use the link.
+                                      %br/
+                                      %br/
+                                      %a{:href => "#{edit_password_url(@resource, :reset_password_token => @token)}", :target => "_blank"}>
+                                        %span{:style => "color:#AF1C1C"} Reset password
+                                      %br/
                                       %br/


### PR DESCRIPTION
## Summary

Show German text first, then a horizontal divider, then the English equivalent in both user-facing Devise email templates.

### Changed files
- `app/views/devise/mailer/confirmation_instructions.html.haml`
- `app/views/devise/mailer/reset_password_instructions.html.haml`

### Confirmation email
- German: greeting, participation link, sign-off
- HR divider
- English: same structure with translated copy

### Reset password email
- German: greeting, reset link, disclaimer
- HR divider
- English: same structure with translated copy (no sign-off, keeping it functional)

### Tests
454 examples, 0 failures