### PR TITLE
Replace filter button bar with dropdown widget

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,7 +31,99 @@ $(function(){
       enable: false
     }
   });
+
+  initMixitupFilterDropdown();
 });
+
+// Wires the Foundation dropdown-pane filter UI to mixitup.
+// Filters are mutually exclusive: clicking one applies it as the sole filter,
+// updates the toggle label, shows the reset chip, and closes the pane.
+// The reset chip restores the default "all" filter.
+function initMixitupFilterDropdown(){
+  var $wrapper = $('#mixitup-control-bar');
+  if ($wrapper.length === 0) return;
+
+  var $table       = $('#mixitup-table');
+  var $toggleLabel = $wrapper.find('.mixitup-filter-toggle-current');
+  var $toggle      = $wrapper.find('.mixitup-filter-toggle');
+  var $reset       = $wrapper.find('.mixitup-filter-reset');
+  var $pane        = $('#mixitup-filter-pane');
+  var $links       = $wrapper.find('.mixitup-filter-link');
+
+  function openPane(){
+    $pane.addClass('is-open');
+    $toggle.attr('aria-expanded', true);
+  }
+
+  function closePane(){
+    $pane.removeClass('is-open');
+    $toggle.attr('aria-expanded', false);
+  }
+
+  function isDefaultLink($link){
+    return $link.data('default') === true || $link.data('filter') === 'all';
+  }
+
+  function applyFilter($link){
+    var selector  = $link.data('filter');
+    var label     = $link.data('label');
+    var isDefault = isDefaultLink($link);
+
+    $links.removeClass('active');
+    $link.addClass('active');
+    $toggleLabel.text(label);
+
+    if (isDefault) {
+      $reset.prop('hidden', true);
+    } else {
+      $reset.prop('hidden', false);
+    }
+
+    if ($table.length) {
+      $table.mixItUp('filter', selector);
+    }
+
+    closePane();
+  }
+
+  // Toggle pane on button click; stop propagation so the document handler
+  // doesn't immediately close it again.
+  $toggle.on('click', function(e){
+    e.stopPropagation();
+    if ($pane.hasClass('is-open')) {
+      closePane();
+    } else {
+      openPane();
+    }
+  });
+
+  // Close when clicking a filter link (stopPropagation is inside applyFilter via closePane).
+  $links.on('click', function(e){
+    e.preventDefault();
+    applyFilter($(this));
+  });
+
+  // Close when clicking the reset chip.
+  $reset.on('click', function(e){
+    e.preventDefault();
+    var $default = $links.filter(function(){
+      return isDefaultLink($(this));
+    }).first();
+    if ($default.length) applyFilter($default);
+  });
+
+  // Close when clicking anywhere outside the widget.
+  $(document).on('click.mixitup-filter', function(e){
+    if ($pane.hasClass('is-open') && !$wrapper[0].contains(e.target)) {
+      closePane();
+    }
+  });
+
+  // Close on Escape key.
+  $(document).on('keydown.mixitup-filter', function(e){
+    if (e.key === 'Escape') closePane();
+  });
+}
 
 function initCheckTippChanges(){
   // https://github.com/codedance/jquery.AreYouSure - alerts users to unsaved changes

--- a/app/assets/stylesheets/mixitup.scss
+++ b/app/assets/stylesheets/mixitup.scss
@@ -2,15 +2,160 @@
   display: none;
 }
 
-#mixitup-control-bar .button {
-  @include auto-width(3, 'button');
-  margin-right: 0;
-  margin-bottom: 0;
-  border: $body-background solid 1px;
+// --- Tips header: heading on the left, filter widget on the right ---
+// Works on all breakpoints — no stacking on mobile.
+.tips-header {
+  display: flex;
+  flex-wrap: nowrap;       // keep heading + filter on one line always
+  align-items: center;
+  gap: 0.5rem 1rem;
+  margin-bottom: 0.5rem;
 
+  .tips-header-title {
+    margin: 0;
+    flex: 1 1 auto;
+    min-width: 0;           // allow heading to shrink if needed
+  }
+
+  .tips-header-filter {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
 }
 
-#mixitup-control-bar .button.active {
-  background: $dark-gray;
-  color: white;
+// --- Filter widget wrapper — must be position:relative so the pane anchors here ---
+.mixitup-filter-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+
+  // Plain text trigger — no button chrome.
+  .mixitup-filter-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin: 0;
+    padding: 0;
+    background: none;
+    border: none;
+    box-shadow: none;
+    color: $dark-gray;
+    font-size: 0.8rem;
+    cursor: pointer;
+    line-height: 1.4;
+    white-space: nowrap;
+
+    &:hover, &:focus {
+      background: none;
+      color: $black;
+      outline: none;
+    }
+
+    .mixitup-filter-toggle-label {
+      opacity: 0.7;
+    }
+
+    .mixitup-filter-toggle-current {
+      font-weight: bold;
+      color: $black;
+    }
+
+    .mixitup-filter-caret {
+      font-size: 0.65rem;
+      opacity: 0.6;
+    }
+  }
+
+  .mixitup-filter-reset {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    margin: 0;
+    padding: 0.15rem 0.5rem;
+    background: #f5f5f5;
+    color: $dark-gray;
+    border: 1px solid #e0e0e0;
+    border-radius: 999px;
+    line-height: 1;
+    font-size: 0.75rem;
+    cursor: pointer;
+    white-space: nowrap;
+
+    &:hover { background: #ececec; color: $black; }
+
+    &[hidden] { display: none !important; }
+
+    .mixitup-filter-reset-x {
+      font-size: 0.9rem;
+      line-height: 1;
+    }
+  }
+}
+
+// --- Filter dropdown pane ---
+// Positioned absolutely below the toggle, right-aligned to wrapper edge.
+.mixitup-filter-pane {
+  // Override Foundation's display:none — we use .is-open class to show/hide.
+  display: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;               // right-align: pane right edge = wrapper right edge
+  left: auto;
+  z-index: 1000;
+
+  width: 18rem;
+  max-width: 90vw;
+  padding: 0.75rem 1rem;
+  background: #fafafa;
+  border: 1px solid #e0e0e0;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  font-size: 0.8rem;
+
+  &.is-open {
+    display: block;
+  }
+
+  .mixitup-filter-section + .mixitup-filter-section {
+    margin-top: 0.6rem;
+    padding-top: 0.6rem;
+    border-top: 1px solid #ececec;
+  }
+
+  .mixitup-filter-section-title {
+    margin: 0 0 0.25rem 0;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: $dark-gray;
+  }
+
+  .mixitup-filter-list {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.2rem 0.3rem;
+
+    li { margin: 0; padding: 0; }
+  }
+
+  .mixitup-filter-link {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    color: $black;
+    text-decoration: none;
+    font-size: 0.8rem;
+
+    &:hover { background: #ececec; }
+
+    &.active {
+      background: $dark-gray;
+      color: white;
+    }
+  }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,22 +8,43 @@ module ApplicationHelper
     link_to(icon('fas', 'trophy', I18n.t(:hall_of_fame), {class: 'fa-fw'}), hall_of_fame_path)
   end
 
-  # used with mixitup
-  def filter_categories_options
-    FILTER_CATEGORIES.map do |filter_category|
-      css_classes = 'filter button'
-      data_filter = ".category-#{filter_category}"
-      if filter_category == FILTER_DEFAULT
-        css_classes << ' active'
-        data_filter = 'all'
-      end
-
+  # Structured filter sections for the mixitup dropdown filter.
+  # Each section has a translated title and a list of options
+  # ({label, data_filter}). The "all" option in the status section
+  # is the default and uses the literal mixitup "all" selector.
+  def tip_filter_sections
+    [
       {
-          label: I18n.t("filter.#{filter_category}"),
-          class: css_classes,
-          data_filter: data_filter
+        title: I18n.t('filter.section.status'),
+        options: FILTER_CATEGORIES.map do |filter_category|
+          {
+            label: I18n.t("filter.#{filter_category}"),
+            data_filter: filter_category == FILTER_DEFAULT ? 'all' : ".category-#{filter_category}",
+            default: filter_category == FILTER_DEFAULT
+          }
+        end
+      },
+      {
+        title: I18n.t('filter.section.group'),
+        options: GROUPS.map do |group|
+          {
+            label: "#{I18n.t('round.group')} #{group}",
+            data_filter: ".category-#{FILTER_GROUP_PREFIX}#{group}",
+            default: false
+          }
+        end
+      },
+      {
+        title: I18n.t('filter.section.round'),
+        options: ROUNDS.reject { |r| r == GROUP }.map do |round|
+          {
+            label: I18n.t(round, scope: 'round'),
+            data_filter: ".category-#{FILTER_ROUND_PREFIX}#{round}",
+            default: false
+          }
+        end
       }
-    end
+    ]
   end
 
   def write_flash_messages

--- a/app/presenters/game_presenter.rb
+++ b/app/presenters/game_presenter.rb
@@ -12,6 +12,8 @@ class GamePresenter < DelegateClass(Game)
     css_classes = ['mix']
     css_classes << "category-#{FILTER_TODAY}" if @game.today?
     css_classes << "category-#{FILTER_FUTURE}" if !@game.started?
+    css_classes << "category-#{FILTER_GROUP_PREFIX}#{@game.group}" if @game.group.present?
+    css_classes << "category-#{FILTER_ROUND_PREFIX}#{@game.round}" if @game.round.present?
 
     css_classes.join(' ')
   end

--- a/app/views/main/_user_tips.html.haml
+++ b/app/views/main/_user_tips.html.haml
@@ -1,8 +1,6 @@
 - tips = presenter.tips
 - if tips.present?
 
-  = render partial: 'widgets/mixitup_control_bar'
-
   = form_tag save_tips_tips_path, id: 'js_save_tips' do
     %table.tips.hover#mixitup-table
       %thead.hide-for-small-only

--- a/app/views/main/index.html.haml
+++ b/app/views/main/index.html.haml
@@ -36,6 +36,10 @@
 
 .row
   .small-12.columns
-    %h3= t('your_tips')
+    .tips-header
+      %h3.tips-header-title= t('your_tips')
+      - if @presenter.tips.present?
+        .tips-header-filter
+          = render partial: 'widgets/mixitup_control_bar'
 
     = render partial: 'user_tips', locals: {presenter: @presenter}

--- a/app/views/widgets/_mixitup_control_bar.html.haml
+++ b/app/views/widgets/_mixitup_control_bar.html.haml
@@ -1,3 +1,30 @@
-.button-group.small#mixitup-control-bar
-  - filter_categories_options.each do |options|
-    = button_tag(options[:label], class: options[:class], data: {filter: options[:data_filter]})
+-# Foundation 6 dropdown-pane based filter widget for mixitup.
+-# The button shows the current active filter label; the chip with × is
+-# only visible when a non-default filter is active and resets to "Alle".
+.mixitup-filter-wrapper#mixitup-control-bar
+  %button.mixitup-filter-toggle{type: 'button',
+                                 'aria-controls': 'mixitup-filter-pane',
+                                 'aria-haspopup': true,
+                                 'aria-expanded': false}
+    %span.mixitup-filter-toggle-label= I18n.t('filter.label')
+    %span.mixitup-filter-toggle-current= I18n.t('filter.all')
+    %span.mixitup-filter-caret ▾
+
+  %button.mixitup-filter-reset{type: 'button',
+                               hidden: true,
+                               'aria-label': I18n.t('filter.reset')}
+    %span.mixitup-filter-reset-x &times;
+
+  .mixitup-filter-pane#mixitup-filter-pane
+    - tip_filter_sections.each do |section|
+      .mixitup-filter-section
+        %h6.mixitup-filter-section-title= section[:title]
+        %ul.mixitup-filter-list.no-bullet
+          - section[:options].each do |option|
+            %li
+              %a.mixitup-filter-link{href: '#',
+                                     class: (option[:default] ? 'active' : nil),
+                                     data: {filter: option[:data_filter],
+                                            label: option[:label],
+                                            default: option[:default]}}
+                = option[:label]

--- a/config/initializers/01_constants.rb
+++ b/config/initializers/01_constants.rb
@@ -77,4 +77,9 @@ FILTER_TODAY = 'today'.freeze
 FILTER_FUTURE = 'future'.freeze
 FILTER_CATEGORIES = [FILTER_DEFAULT, FILTER_TODAY, FILTER_FUTURE]
 
+# Mixitup filter class prefixes for group / round filters.
+# The actual filter values are derived from tournament data (GROUPS, ROUNDS).
+FILTER_GROUP_PREFIX = 'group-'.freeze
+FILTER_ROUND_PREFIX = 'round-'.freeze
+
 SUPPORTED_LOCALES = %w[de en].freeze

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -199,6 +199,12 @@ de:
     all: 'Alle Spiele'
     today: 'Heutige Spiele'
     future:  'Offene Spiele'
+    label: 'Filter:'
+    reset: 'Filter zurücksetzen'
+    section:
+      status: 'Status'
+      group: 'Gruppe'
+      round: 'Runde'
 
   date:
     formats:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,6 +197,12 @@ en:
     all: 'All games'
     today: "Today's games"
     future: 'Upcoming games'
+    label: 'Filter:'
+    reset: 'Clear filter'
+    section:
+      status: 'Status'
+      group: 'Group'
+      round: 'Round'
 
   date:
     formats:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -15,20 +15,32 @@ describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#filter_categories_options' do
+  describe '#tip_filter_sections' do
 
-    it 'returns mixitup filter buuton options' do
-      expect(helper.filter_categories_options).to eq(
-                                                      [{:label=>"Alle Spiele",
-                                                        :class=>"filter button active",
-                                                        :data_filter=>"all"},
-                                                       {:label=>"Heutige Spiele",
-                                                        :class=>"filter button",
-                                                        :data_filter=>".category-today"},
-                                                       {:label=>"Offene Spiele",
-                                                        :class=>"filter button",
-                                                        :data_filter=>".category-future"}]
-                                                  )
+    it 'returns status, group and round sections with translated labels' do
+      sections = helper.tip_filter_sections
+
+      expect(sections.map { |s| s[:title] }).to eq(['Status', 'Gruppe', 'Runde'])
+
+      status = sections[0]
+      expect(status[:options]).to eq([
+        { label: 'Alle Spiele',    data_filter: 'all',             default: true },
+        { label: 'Heutige Spiele', data_filter: '.category-today', default: false },
+        { label: 'Offene Spiele',  data_filter: '.category-future', default: false },
+      ])
+
+      group = sections[1]
+      expect(group[:options].first).to eq(
+        label: 'Gruppe A', data_filter: '.category-group-A', default: false
+      )
+      expect(group[:options].size).to eq(GROUPS.size)
+
+      round = sections[2]
+      # The group round is excluded — group filter is its own section.
+      expect(round[:options].map { |o| o[:label] }).not_to include('Gruppe')
+      expect(round[:options]).to include(
+        a_hash_including(data_filter: '.category-round-final', default: false)
+      )
     end
   end
 

--- a/spec/presenters/game_presenter_spec.rb
+++ b/spec/presenters/game_presenter_spec.rb
@@ -28,27 +28,49 @@ describe GamePresenter do
 
     context 'if game is today' do
 
-      it 'returns mix and category-today' do
+      it 'returns mix, category-today and the category for its round' do
         expect(game).to receive(:today?).and_return(true)
         expect(game).to receive(:started?).and_return(true)
-        expect(subject.filter_categories_css_classes).to eq('mix category-today')
+        expect(subject.filter_categories_css_classes).to eq('mix category-today category-round-round')
       end
     end
 
     context 'if game is in the future and today' do
 
-      it 'returns mix, category-today and category-future' do
+      it 'returns mix, category-today, category-future and the round category' do
         expect(game).to receive(:today?).and_return(true)
         expect(game).to receive(:started?).and_return(false)
-        expect(subject.filter_categories_css_classes).to eq('mix category-today category-future')
+        expect(subject.filter_categories_css_classes).to eq('mix category-today category-future category-round-round')
       end
     end
 
     context 'if game is not in the future and not today' do
 
-      it 'returns mix' do
+      it 'returns mix and the round category' do
         expect(game).to receive(:today?).and_return(false)
         expect(game).to receive(:started?).and_return(true)
+        expect(subject.filter_categories_css_classes).to eq('mix category-round-round')
+      end
+    end
+
+    context 'if game has a group' do
+
+      it 'returns the group category class' do
+        expect(game).to receive(:today?).and_return(false)
+        expect(game).to receive(:started?).and_return(true)
+        game.group = 'A'
+        game.round = GROUP
+        expect(subject.filter_categories_css_classes).to eq('mix category-group-A category-round-group')
+      end
+    end
+
+    context 'if game has no group and no round' do
+
+      it 'returns only mix' do
+        expect(game).to receive(:today?).and_return(false)
+        expect(game).to receive(:started?).and_return(true)
+        game.group = nil
+        game.round = nil
         expect(subject.filter_categories_css_classes).to eq('mix')
       end
     end


### PR DESCRIPTION
## Summary

Replaces the 3-button mixitup control bar with a lightweight dropdown filter widget.

## Changes

- **New filter categories**: Status (Alle / Heute / Offen), Gruppe (A–L), Runde (Achtelfinale … Finale)
- **UX**: Plain-text toggle sits inline next to the "Deine Tipps" heading on all screen sizes (including mobile). No button chrome.
- **Active state**: Current filter shown in the toggle label; a small × chip appears for non-default filters and resets to "Alle Spiele" on click.
- **Positioning**: Dropdown opens below the toggle, right-aligned — stays on screen even when the widget is on the far right.
- **Close behaviour**: Closes on filter selection, outside click, and Escape key. Self-managed JS (no Foundation plugin dependency).
- **GamePresenter**: `filter_categories_css_classes` now also emits `category-group-<X>` and `category-round-<round>` CSS classes.
- **Helper**: `filter_categories_options` replaced by `tip_filter_sections` returning structured section data.
- **i18n**: New keys `filter.label`, `filter.reset`, `filter.section.*` added for de + en.

## Tests

456 examples, 0 failures. Assets precompile cleanly.