### PR TITLE
Silence bot/scanner 404s in RoutingErrorsController

### DIFF
--- a/app/controllers/routing_errors_controller.rb
+++ b/app/controllers/routing_errors_controller.rb
@@ -7,7 +7,29 @@ class RoutingErrorsController < ApplicationController
   # the ActionController::RoutingError. This is necessary to let ExceptionNotification handle this error by sending
   # an error mail because normally ActionController::RoutingError is already called in the middleware where
   # ExceptionNotification is not yet aware of it up to version 4.1.4.
+  #
+  # Bot/scanner probes (WordPress, PHP, .env harvesting, .git probes) are silently returned
+  # as 404 without raising an exception, to avoid noise in logs and notification emails.
   def show
-    raise ActionController::RoutingError, "Unknown route #{params[:unknown_route]}"
+    path = params[:unknown_route].to_s
+    if bot_scan?(path)
+      head :not_found
+    else
+      raise ActionController::RoutingError, "Unknown route #{path}"
+    end
+  end
+
+  private
+
+  def bot_scan?(path)
+    # PHP file probes (WordPress exploit scanners, generic PHP probes)
+    return true if path.end_with?(".php") || path.match?(/\.php\d*\z/i)
+    # WordPress-specific paths
+    return true if path.start_with?("wp-", "wp-content/", "wp-admin/", "wp-includes/")
+    # Credential/config file harvesting and git probes
+    return true if path.start_with?(".env", ".git/", "cgi-bin")
+    # .env files nested in subdirectories (e.g. app/.env, laravel/.env, api/v1/.env)
+    return true if path.match?(/\.env[\w.\-~]*\z/)
+    false
   end
 end

--- a/spec/controllers/routing_errors_controller_spec.rb
+++ b/spec/controllers/routing_errors_controller_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+describe RoutingErrorsController do
+
+  describe 'GET #show' do
+
+    context 'with bot/scanner paths' do
+
+      context 'PHP file probes' do
+        it 'returns 404 silently for .php files' do
+          get :show, params: { unknown_route: 'admin.php' }
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'returns 404 silently for wp-login.php' do
+          get :show, params: { unknown_route: 'wp-login.php' }
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'returns 404 silently for mixed-case PHP extension like .PhP7' do
+          get :show, params: { unknown_route: 'randkeyword.PhP7' }
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'does not raise an exception for PHP probes' do
+          expect { get :show, params: { unknown_route: 'xmlrpc.php' } }.not_to raise_error
+        end
+      end
+
+      context 'WordPress path probes' do
+        it 'returns 404 silently for wp- prefixed paths' do
+          get :show, params: { unknown_route: 'wp-content/uploads/index.php' }
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'returns 404 silently for wp-admin' do
+          get :show, params: { unknown_route: 'wp-admin/user.php' }
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'returns 404 silently for wp-includes' do
+          get :show, params: { unknown_route: 'wp-includes/PHPMailer' }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context '.env file harvesting' do
+        it 'returns 404 silently for .env' do
+          get :show, params: { unknown_route: '.env' }
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'returns 404 silently for .env.local' do
+          get :show, params: { unknown_route: '.env.local' }
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'returns 404 silently for .env.production' do
+          get :show, params: { unknown_route: '.env.production' }
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'returns 404 silently for .env nested in a subdirectory' do
+          get :show, params: { unknown_route: 'laravel/.env' }
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'returns 404 silently for .env nested deeply' do
+          get :show, params: { unknown_route: 'api/v1/.env' }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context '.git probes' do
+        it 'returns 404 silently for .git/config' do
+          get :show, params: { unknown_route: '.git/config' }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context 'cgi-bin probes' do
+        it 'returns 404 silently for cgi-bin' do
+          get :show, params: { unknown_route: 'cgi-bin' }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'with legitimate unknown routes' do
+      it 'raises ActionController::RoutingError for a genuinely unknown path' do
+        expect { get :show, params: { unknown_route: 'some/unknown/app/path' } }
+          .to raise_error(ActionController::RoutingError, /Unknown route some\/unknown\/app\/path/)
+      end
+
+      it 'raises ActionController::RoutingError for a typo in a real route' do
+        expect { get :show, params: { unknown_route: 'halll-of-fame' } }
+          .to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Automated vulnerability scanners were hitting the catch-all route with WordPress paths, PHP file probes, `.env` credential harvesting attempts, and `.git/config` probes. Each one produced a FATAL log entry and triggered an `exception_notification` email.

## Solution

Add a `bot_scan?` private method in `RoutingErrorsController#show`. Known scanner patterns return a silent `head :not_found` — no exception raised, no email sent, no FATAL log. Legitimate unknown routes still raise `ActionController::RoutingError` and trigger notifications as before.

**Patterns silenced:**
- `*.php` / `*.PhP7` files
- `wp-\*`, `wp-content/`, `wp-admin/`, `wp-includes/` paths
- `.env`, `.env.*`, `<dir>/.env` credential harvesting
- `.git/` config probes
- `cgi-bin` probes

## Testing

Added `spec/controllers/routing_errors_controller_spec.rb` covering all `bot_scan?` branches and verifying legitimate routes still raise.

```
472 examples, 0 failures
```

No new gems required.