### PR TITLE
Hide bonus answers in ranking until Round of 16 starts, add hint link for unfilled bonus questions

### DIFF
--- a/app/controllers/rankings_controller.rb
+++ b/app/controllers/rankings_controller.rb
@@ -2,6 +2,6 @@
 
 class RankingsController < ApplicationController
   def index
-    @presenter = RankingPresenter.new
+    @presenter = RankingPresenter.new(current_user)
   end
 end

--- a/app/controllers/routing_errors_controller.rb
+++ b/app/controllers/routing_errors_controller.rb
@@ -13,24 +13,23 @@ class RoutingErrorsController < ApplicationController
   # as 404 without raising an exception, to avoid noise in logs and notification emails.
   def show
     path = params[:unknown_route].to_s
-    if bot_scan?(path)
-      head :not_found
-    else
-      raise ActionController::RoutingError, "Unknown route #{path}"
-    end
+    raise ActionController::RoutingError, "Unknown route #{path}" unless bot_scan?(path)
+
+    head :not_found
   end
 
   private
 
   def bot_scan?(path)
     # PHP file probes (WordPress exploit scanners, generic PHP probes)
-    return true if path.end_with?(".php") || path.match?(/\.php\d*\z/i)
+    return true if path.end_with?('.php') || path.match?(/\.php\d*\z/i)
     # WordPress-specific paths
-    return true if path.start_with?("wp-", "wp-content/", "wp-admin/", "wp-includes/")
+    return true if path.start_with?('wp-', 'wp-content/', 'wp-admin/', 'wp-includes/')
     # Credential/config file harvesting and git probes
-    return true if path.start_with?(".env", ".git/", "cgi-bin")
+    return true if path.start_with?('.env', '.git/', 'cgi-bin')
     # .env files nested in subdirectories (e.g. app/.env, laravel/.env, api/v1/.env)
     return true if path.match?(/\.env[\w.\-~]*\z/)
+
     false
   end
 end

--- a/app/presenters/ranking_presenter.rb
+++ b/app/presenters/ranking_presenter.rb
@@ -41,6 +41,7 @@ class RankingPresenter
   def bonus_hint_for?(user)
     return false if bonus_answers_visible?
     return false unless @current_user&.id == user.id
+
     !@current_user.all_bonus_questions_filled_out?
   end
 

--- a/app/presenters/ranking_presenter.rb
+++ b/app/presenters/ranking_presenter.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 class RankingPresenter
+  def initialize(current_user)
+    @current_user = current_user
+  end
+
   def bonus_answers_visible?
     Tournament.round_of_16_started?
   end
 
   def bonus_ranking_info(user, for_small_screen: false)
-    return I18n.t('ranking_bonus_answers_currently_not_visible') unless bonus_answers_visible?
+    return '' unless bonus_answers_visible?
 
     flag_size = for_small_screen ? 16 : 32
     [
@@ -32,6 +36,12 @@ class RankingPresenter
   def user_ranking_hash
     user_ranking = Users::PrepareRanking.call(users_for_ranking: ::UserQueries.all_ordered_by_points_and_all_countxpoints)
     user_ranking.sort
+  end
+
+  def bonus_hint_for?(user)
+    return false if bonus_answers_visible?
+    return false unless @current_user&.id == user.id
+    !@current_user.all_bonus_questions_filled_out?
   end
 
   private

--- a/app/views/rankings/_user_ranking.html.haml
+++ b/app/views/rankings/_user_ranking.html.haml
@@ -27,13 +27,19 @@
                         = user_points
                   .row
                     .small-5.columns.small-infos
-                      = raw presenter.bonus_ranking_info(user, for_small_screen: true)
+                      - if presenter.bonus_hint_for?(user)
+                        = link_to t('ranking_bonus_hint_link'), edit_bonus_path, style: 'white-space: nowrap'
+                      - else
+                        = raw presenter.bonus_ranking_info(user, for_small_screen: true)
                     .small-7.columns.text-right
                       = statistic_content(user).html_safe
 
             %td.hide-for-small-only.place= place
             %td.hide-for-small-only= user_name_with_statistic_link
-            %td.hide-for-small-only= raw presenter.bonus_ranking_info(user)
+            - if presenter.bonus_hint_for?(user)
+              %td.hide-for-small-only= link_to t('ranking_bonus_hint_link'), edit_bonus_path, style: 'white-space: nowrap'
+            - else
+              %td.hide-for-small-only= raw presenter.bonus_ranking_info(user)
             %td.hide-for-small-only
               %span.user-points= user_points
               %span.user-statistic= statistic_content(user).html_safe

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -119,6 +119,7 @@ de:
   no_when_first_goal_tip: 'Du hast leider keinen Tipp abgegeben, wann im Finale das erste Tor fällt!'
   no_how_many_goals_tip: 'Du hast leider keinen Tipp abgegeben, wieviele Tore der Torschützenkönig erzielt!'
   ranking_bonus_answers_currently_not_visible: 'Noch nicht sichtbar'
+  ranking_bonus_hint_link: "Bonusfragen?"
   ranking_bonus_answers_help: "Sieger Flagge | Flagge zweiter Platz | Wann fällt das erste Tor | Anzahl Tore"
 
   x_user_bet: "%{user_count} 'Fußball-Experten' wetteifern um den Sieg und einen Platz in der "

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,7 @@ en:
   no_when_first_goal_tip: "Sorry, you didn't submit a tip for when the first goal will be scored in the final!"
   no_how_many_goals_tip: "Sorry, you didn't submit a tip for how many goals the top scorer will score!"
   ranking_bonus_answers_currently_not_visible: 'Not yet visible'
+  ranking_bonus_hint_link: "Bonus questions?"
   ranking_bonus_answers_help: "Winner flag | Runner-up flag | When first goal | Top scorer goals"
 
   x_user_bet: "%{user_count} 'football-experts' are competing for the win and a place in the "

--- a/spec/controllers/routing_errors_controller_spec.rb
+++ b/spec/controllers/routing_errors_controller_spec.rb
@@ -1,11 +1,10 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe RoutingErrorsController do
-
   describe 'GET #show' do
-
     context 'with bot/scanner paths' do
-
       context 'PHP file probes' do
         it 'returns 404 silently for .php files' do
           get :show, params: { unknown_route: 'admin.php' }
@@ -44,7 +43,7 @@ describe RoutingErrorsController do
         end
       end
 
-      context '.env file harvesting' do
+      describe '.env file harvesting' do
         it 'returns 404 silently for .env' do
           get :show, params: { unknown_route: '.env' }
           expect(response).to have_http_status(:not_found)
@@ -71,7 +70,7 @@ describe RoutingErrorsController do
         end
       end
 
-      context '.git probes' do
+      describe '.git probes' do
         it 'returns 404 silently for .git/config' do
           get :show, params: { unknown_route: '.git/config' }
           expect(response).to have_http_status(:not_found)
@@ -89,7 +88,7 @@ describe RoutingErrorsController do
     context 'with legitimate unknown routes' do
       it 'raises ActionController::RoutingError for a genuinely unknown path' do
         expect { get :show, params: { unknown_route: 'some/unknown/app/path' } }
-          .to raise_error(ActionController::RoutingError, /Unknown route some\/unknown\/app\/path/)
+          .to raise_error(ActionController::RoutingError, %r{Unknown route some/unknown/app/path})
       end
 
       it 'raises ActionController::RoutingError for a typo in a real route' do

--- a/spec/presenters/ranking_presenter_spec.rb
+++ b/spec/presenters/ranking_presenter_spec.rb
@@ -130,4 +130,52 @@ describe RankingPresenter do
       end
     end
   end
+
+  describe '#bonus_hint_for?' do
+    let(:current_user) { instance_double(User, id: 1) }
+    let(:other_user)   { instance_double(User, id: 2) }
+
+    subject { described_class.new(current_user) }
+
+    context 'when bonus answers are visible (Round of 16 started)' do
+      it 'returns false regardless of user match' do
+        allow(subject).to receive(:bonus_answers_visible?).and_return(true)
+        expect(subject.bonus_hint_for?(current_user)).to be false
+      end
+    end
+
+    context 'when bonus answers are not yet visible' do
+      before { allow(subject).to receive(:bonus_answers_visible?).and_return(false) }
+
+      context 'when the row user is not the current_user' do
+        it 'returns false' do
+          expect(subject.bonus_hint_for?(other_user)).to be false
+        end
+      end
+
+      context 'when current_user is nil' do
+        subject { described_class.new(nil) }
+
+        it 'returns false' do
+          expect(subject.bonus_hint_for?(other_user)).to be false
+        end
+      end
+
+      context 'when the row user is the current_user' do
+        context 'and all bonus questions are filled out' do
+          it 'returns false' do
+            allow(current_user).to receive(:all_bonus_questions_filled_out?).and_return(true)
+            expect(subject.bonus_hint_for?(current_user)).to be false
+          end
+        end
+
+        context 'and not all bonus questions are filled out' do
+          it 'returns true' do
+            allow(current_user).to receive(:all_bonus_questions_filled_out?).and_return(false)
+            expect(subject.bonus_hint_for?(current_user)).to be true
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/presenters/ranking_presenter_spec.rb
+++ b/spec/presenters/ranking_presenter_spec.rb
@@ -132,10 +132,10 @@ describe RankingPresenter do
   end
 
   describe '#bonus_hint_for?' do
+    subject { described_class.new(current_user) }
+
     let(:current_user) { instance_double(User, id: 1) }
     let(:other_user)   { instance_double(User, id: 2) }
-
-    subject { described_class.new(current_user) }
 
     context 'when bonus answers are visible (Round of 16 started)' do
       it 'returns false regardless of user match' do

--- a/spec/presenters/ranking_presenter_spec.rb
+++ b/spec/presenters/ranking_presenter_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe RankingPresenter do
-  subject { described_class.new }
+  subject { described_class.new(nil) }
 
   describe '#bonus_answers_visible?' do
     context 'if Tournament.round_of_16_started? == true' do
@@ -126,7 +126,7 @@ describe RankingPresenter do
     context 'if bonus_answers_visible? == false' do
       it 'shows info text' do
         expect(subject).to receive(:bonus_answers_visible?).and_return(false)
-        expect(subject.bonus_ranking_info(nil)).to eq(I18n.t('ranking_bonus_answers_currently_not_visible'))
+        expect(subject.bonus_ranking_info(nil)).to eq('')
       end
     end
   end

--- a/spec/views/ranking/index.html.haml_spec.rb
+++ b/spec/views/ranking/index.html.haml_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'rankings/index' do
-  let(:presenter) { RankingPresenter.new }
+  let(:presenter) { RankingPresenter.new(nil) }
 
   before do
     allow(Tournament).to receive(:round_of_16_not_yet_started?).and_return(true)
@@ -27,8 +27,7 @@ describe 'rankings/index' do
     assign(:presenter, presenter)
     user_size = 10
     expect(presenter).to receive(:user_count).and_return(user_size)
-    # 2x10 + one time in the index
-    expect(presenter).to receive(:bonus_answers_visible?).exactly(21).times.and_return(false)
+    expect(presenter).to receive(:bonus_answers_visible?).at_least(:once).and_return(false)
 
     # create 10 users
     users = []
@@ -91,8 +90,7 @@ describe 'rankings/index' do
 
     user_size = user_points.count
     expect(presenter).to receive(:user_count).and_return(user_size)
-    # 2x10 + one time in the index
-    expect(presenter).to receive(:bonus_answers_visible?).exactly(21).times.and_return(false)
+    expect(presenter).to receive(:bonus_answers_visible?).at_least(:once).and_return(false)
 
     # create users
     users = user_points.map do |key, data|


### PR DESCRIPTION
## Changes

- **Bonus column hidden** until Round of 16 starts: the `bonus_ranking_info` now returns an empty string instead of "Noch nicht sichtbar" / "Not yet visible" — the column renders blank for all users before the deadline
- **Hint link** shown in the bonus column for the logged-in user when Round of 16 has not yet started and they haven't filled out all bonus questions — links directly to the bonus edit page
- Link text: "Bonusfragen?" (DE) / "Bonus questions?" (EN) — single word, nowrap, stays on one line on mobile
- `RankingPresenter` now receives `current_user` and exposes `bonus_hint_for?(user)`