### PR TITLE
Upgrade tier-4 gems: misc minor/patch bumps + pin parallel < 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ end
 
 group :development do
   gem 'letter_opener_web'
+  gem 'parallel', '< 2' # 2.x requires Ruby >= 3.3; we're on 3.2.x
   gem 'rack-livereload'
   gem 'rack-mini-profiler'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     devise-encryptable (0.2.0)
       devise (>= 2.1.0)
     diff-lcs (1.6.2)
-    docile (1.4.0)
+    docile (1.4.1)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
       dotenv (= 3.2.0)
@@ -200,8 +200,8 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.4)
-    matrix (0.4.2)
+    marcel (1.1.0)
+    matrix (0.4.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.27.0)
@@ -221,7 +221,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     net-ssh (7.3.2)
-    nio4r (2.7.3)
+    nio4r (2.7.5)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
@@ -246,7 +246,7 @@ GEM
     rack (2.2.23)
     rack-livereload (0.5.2)
       rack (< 3)
-    rack-mini-profiler (3.3.1)
+    rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
     rack-test (2.2.0)
       rack (>= 1.3)
@@ -294,7 +294,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.4.4)
-    rspec (3.13.0)
+    rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
@@ -368,7 +368,7 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
+    simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     sprockets (3.7.3)
       base64
@@ -389,9 +389,9 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
-    temple (0.10.3)
+    temple (0.10.4)
     thor (1.5.0)
-    tilt (2.3.0)
+    tilt (2.7.0)
     timecop (0.9.11)
     timeout (0.6.1)
     tzinfo (2.0.6)
@@ -403,8 +403,9 @@ GEM
     unicode-emoji (4.2.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webrick (1.8.1)
-    websocket-driver (0.7.6)
+    webrick (1.9.2)
+    websocket-driver (0.8.0)
+      base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     whenever (1.1.2)
@@ -442,6 +443,7 @@ DEPENDENCIES
   lograge
   minitest (< 6)
   mysql2 (~> 0.5.6)
+  parallel (< 2)
   passenger (~> 6.1)
   rack-livereload
   rack-mini-profiler


### PR DESCRIPTION
## What

Miscellaneous minor and patch-level gem bumps, plus a safety pin for `parallel`.

| Gem | From | To | Notes |
|-----|------|----|-------|
| rack-mini-profiler | 3.3.1 | 4.0.1 | Ruby ≥ 3.1 required (fine); 4.0.1 explicitly fixes Rack 2/3 cross-compat |
| rspec | 3.13.0 | 3.13.2 | patch |
| docile | 1.4.0 | 1.4.1 | patch (simplecov dep) |
| simplecov-html | 0.12.3 | 0.13.2 | minor |
| marcel | 1.0.4 | 1.1.0 | minor |
| matrix | 0.4.2 | 0.4.3 | patch |
| nio4r | 2.7.3 | 2.7.5 | patch |
| websocket-driver | 0.7.6 | 0.8.0 | minor |
| tilt | 2.3.0 | 2.7.0 | minor |
| temple | 0.10.3 | 0.10.4 | patch (haml dep) |
| webrick | 1.9.1 | 1.9.2 | patch |
| parallel | 1.28.0 | 1.28.0 | **pinned `< 2`** — 2.x requires Ruby ≥ 3.3; we're on 3.2.x |

Not bumped (already at latest in their allowed range): , , , .

## Checks

- Rubocop: 0 offenses
- RSpec: 477 examples, 0 failures