### PR TITLE
Bulk-optimize Tips::UpdatePoints and Users::UpdateRankingPerGame

### DIFF
--- a/app/models/tips/tip_queries.rb
+++ b/app/models/tips/tip_queries.rb
@@ -64,5 +64,16 @@ module TipQueries
       rows.each { |(uid, pts), cnt| result[uid][pts] = cnt }
       result
     end
+
+    # Returns an array of [tip_id, tip_team1_goals, tip_team2_goals,
+    #                      game_team1_goals, game_team2_goals] rows for every
+    # tip belonging to a finished game. Single query replacing the
+    # per-finished-game SELECT loop in Tips::UpdatePoints.
+    def all_tips_with_game_results_for_finished_games
+      Tip.joins(:game)
+         .where(games: { finished: true })
+         .pluck(:id, :team1_goals, :team2_goals,
+                'games.team1_goals', 'games.team2_goals')
+    end
   end
 end

--- a/app/models/tips/tip_queries.rb
+++ b/app/models/tips/tip_queries.rb
@@ -67,11 +67,18 @@ module TipQueries
 
     # Returns an array of [tip_id, tip_team1_goals, tip_team2_goals,
     #                      game_team1_goals, game_team2_goals] rows for every
-    # tip belonging to a finished game. Single query replacing the
-    # per-finished-game SELECT loop in Tips::UpdatePoints.
+    # tip belonging to a finished game whose result is fully recorded.
+    # Single query replacing the per-finished-game SELECT loop in
+    # Tips::UpdatePoints.
+    #
+    # Games are filtered to those with both team1_goals and team2_goals set,
+    # because admins can mark a game finished without entering goals — those
+    # games must be skipped (matches the legacy `winner(game)` nil-guard).
     def all_tips_with_game_results_for_finished_games
       Tip.joins(:game)
          .where(games: { finished: true })
+         .where.not(games: { team1_goals: nil })
+         .where.not(games: { team2_goals: nil })
          .pluck(:id, :team1_goals, :team2_goals,
                 'games.team1_goals', 'games.team2_goals')
     end

--- a/app/services/tips/update_points.rb
+++ b/app/services/tips/update_points.rb
@@ -47,6 +47,10 @@ module Tips
     end
 
     def points_for_row(tip_t1, tip_t2, game_t1, game_t2)
+      # Defense in depth: the bulk query already filters games with missing
+      # goals, but a finished game without a recorded result must always be
+      # skipped — matches the legacy winner(game) nil-guard.
+      return 0 if game_t1.blank? || game_t2.blank?
       return 0 if tip_t1.blank? || tip_t2.blank?
 
       calculate_tip_points(winner_from_goals(game_t1, game_t2),

--- a/app/services/tips/update_points.rb
+++ b/app/services/tips/update_points.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
-# Berechnet fuer alle beendeten Spiele alle Nutzer-Tipp-Punkte
+# Calculates tip points for all tips belonging to finished games.
+#
+# Bulk strategy (see Tips::UpdatePoints refactoring):
+#   1. A single SELECT loads all tips for all finished games together with
+#      the game result (TipQueries.all_tips_with_game_results_for_finished_games).
+#   2. Points are computed in Ruby via calculate_tip_points (single source of truth).
+#   3. Tips are grouped by computed point value; one UPDATE per distinct
+#      point value is issued. This yields at most as many UPDATEs as there
+#      are distinct point values (currently 6: 0, 1, 3, 4, 5, 8).
 module Tips
   class UpdatePoints < BaseService
     MAX_POINTS_PRO_TIP   = TipPoints::PERFECT
@@ -13,55 +21,57 @@ module Tips
     TEAM2_WIN = 2
 
     def call
-      games = Game.all
-      games.each do |game|
-        if game.finished?
-          Rails.logger.presence&.info("UPDATE_ALL_TIPP_POINTS: for game-id #{game.id}")
-          update_all_tip_points_for(game)
-        end
+      rows = ::TipQueries.all_tips_with_game_results_for_finished_games
+      return if rows.blank?
+
+      ids_by_points = group_tip_ids_by_points(rows)
+
+      ids_by_points.each do |points, tip_ids|
+        # rubocop:disable Rails/SkipsModelValidations -- bulk perf update, no callbacks needed
+        ::Tip.where(id: tip_ids).update_all(tip_points: points)
+        # rubocop:enable Rails/SkipsModelValidations
       end
     end
 
     private
 
-    def update_all_tip_points_for(game)
-      return if game.blank?
+    def group_tip_ids_by_points(rows)
+      result = Hash.new { |h, k| h[k] = [] }
 
-      game_winner = winner(game)
-
-      return if game_winner.blank?
-
-      tips = ::Tip.where(game_id: game.id)
-      return if tips.blank?
-
-      # mass-updating
-      sql_when_values = []
-      sql_where_all_ids = tips.map(&:id)
-
-      tips.each do |tip|
-        points = 0
-        if tip.team1_goals.present? && tip.team2_goals.present?
-          points = calculate_tip_points(game_winner,
-                                        game.team1_goals, game.team2_goals,
-                                        tip.team1_goals, tip.team2_goals)
-        end
-        sql_when_values << "WHEN id = #{tip.id} THEN #{points}"
+      rows.each do |tip_id, tip_t1, tip_t2, game_t1, game_t2|
+        points = points_for_row(tip_t1, tip_t2, game_t1, game_t2)
+        result[points] << tip_id
       end
-      sql = "UPDATE tips SET tip_points = CASE #{sql_when_values.join(' ')} END WHERE id IN (#{sql_where_all_ids.join(',')})"
-      ::Tip.connection.execute(sql)
+
+      result
+    end
+
+    def points_for_row(tip_t1, tip_t2, game_t1, game_t2)
+      return 0 if tip_t1.blank? || tip_t2.blank?
+
+      calculate_tip_points(winner_from_goals(game_t1, game_t2),
+                           game_t1, game_t2, tip_t1, tip_t2)
+    end
+
+    def winner_from_goals(game_team1_goals, game_team2_goals)
+      return TEAM1_WIN if game_team1_goals > game_team2_goals
+      return TEAM2_WIN if game_team1_goals < game_team2_goals
+
+      DRAW
     end
 
     def calculate_tip_points(game_winner, game_team1_goals, game_team2_goals, tip_team1_goals, tip_team2_goals)
       points = 0
       points += POINTS_CORRECT_TREND if correct_trend?(game_winner, tip_team1_goals, tip_team2_goals)
 
-      # nur wenn die Spieltendenz stimmt, gibt es auch die Punkte auf die richtige Toranzahl pro Team
+      # only when the trend (winner) is correct, award extra points for
+      # correctly guessing the goal count of each team
       if points == POINTS_CORRECT_TREND
         points += EXTRA_POINT_GOALS if game_team1_goals == tip_team1_goals
         points += EXTRA_POINT_GOALS if game_team2_goals == tip_team2_goals
       end
 
-      # 1 Punkt fuer richtige Tordifferenz
+      # 1 point for correct goal difference
       goal_diff = tip_team1_goals - tip_team2_goals
       game_diff = game_team1_goals - game_team2_goals
       points += EXTRA_POINT if goal_diff == game_diff
@@ -73,18 +83,6 @@ module Tips
       (game_winner == DRAW && tip_team1_goals == tip_team2_goals) ||
         (game_winner == TEAM1_WIN && tip_team1_goals > tip_team2_goals) ||
         (game_winner == TEAM2_WIN && tip_team1_goals < tip_team2_goals)
-    end
-
-    # wer hat gewonnen Team1 oder Team2, unentschieden == 0
-    def winner(game)
-      result = nil
-      if game.team1_goals.present? && game.team2_goals.present?
-        result = TEAM1_WIN if game.team1_goals > game.team2_goals
-        result = TEAM2_WIN if game.team1_goals < game.team2_goals
-        result = DRAW if game.team1_goals == game.team2_goals
-      end
-
-      result
     end
   end
 end

--- a/app/services/users/update_ranking_per_game.rb
+++ b/app/services/users/update_ranking_per_game.rb
@@ -2,68 +2,110 @@
 
 module Users
   class UpdateRankingPerGame < UserBaseService
-    def call # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity -- per-game ranking algorithm; complexity is intrinsic to the place-assignment logic
-      finished_games  = ::GameQueries.all_finished_ordered_by_start_at_with_preload_tips
-      all_8point_tips = ::TipQueries.all_by_games_and_tip_points(finished_games, TipPoints::PERFECT)
-      all_5point_tips = ::TipQueries.all_by_games_and_tip_points(finished_games, TipPoints::CORRECT_GOALS_ONE_TEAM)
-      all_4point_tips = ::TipQueries.all_by_games_and_tip_points(finished_games, TipPoints::CORRECT_GOALS)
-      all_3point_tips = ::TipQueries.all_by_games_and_tip_points(finished_games, TipPoints::CORRECT_TREND)
+    # Per-game ranking algorithm.
+    #
+    # Bulk strategy (see refactoring):
+    #   - Cumulative per-user counts (8/5/4/3 point tips AND total tip points)
+    #     are maintained in Ruby, no SQL per game.
+    #   - ranking_place values are collected across all games and written in
+    #     a few UPDATEs at the end (grouped by ranking_place value).
+    def call
+      finished_games = ::GameQueries.all_finished_ordered_by_start_at_with_preload_tips
+      return true if finished_games.blank?
 
-      # Pre-build lookup hashes: { game_id => Set<user_id> }
-      # O(1) membership check instead of scanning the full array each iteration.
-      index_8 = build_game_user_index(all_8point_tips) # rubocop:disable Naming/VariableNumber
-      index_5 = build_game_user_index(all_5point_tips) # rubocop:disable Naming/VariableNumber
-      index_4 = build_game_user_index(all_4point_tips) # rubocop:disable Naming/VariableNumber
-      index_3 = build_game_user_index(all_3point_tips) # rubocop:disable Naming/VariableNumber
-
-      # Cumulative per-user counts that grow as we walk through games in order.
-      cum_8 = Hash.new(0) # rubocop:disable Naming/VariableNumber
-      cum_5 = Hash.new(0) # rubocop:disable Naming/VariableNumber
-      cum_4 = Hash.new(0) # rubocop:disable Naming/VariableNumber
-      cum_3 = Hash.new(0) # rubocop:disable Naming/VariableNumber
-      used_game_ids = []
-
-      finished_games.each do |game|
-        tips_for_game  = game.tips
-        used_game_ids << game.id
-
-        # Increment only the users who scored on this specific game — O(users_in_game).
-        (index_8[game.id] || []).each { |uid| cum_8[uid] += 1 }
-        (index_5[game.id] || []).each { |uid| cum_5[uid] += 1 }
-        (index_4[game.id] || []).each { |uid| cum_4[uid] += 1 }
-        (index_3[game.id] || []).each { |uid| cum_3[uid] += 1 }
-
-        ordered_user_id_and_ranking_comparison_value =
-          get_ordered_user_id_and_ranking_comparison_value(cum_8, cum_5, cum_4, cum_3, used_game_ids)
-
-        result_for_this_game     = {}
-        place                    = 1
-        user_count_on_same_place = 1
-        last_ranking_comparison_value = nil
-
-        ordered_user_id_and_ranking_comparison_value.each do |user_id, ranking_comparison_value|
-          if last_ranking_comparison_value.nil?
-            # erste User
-            result_for_this_game[place] = [user_id]
-          elsif last_ranking_comparison_value > ranking_comparison_value
-            place += user_count_on_same_place
-            result_for_this_game[place] = [user_id]
-            user_count_on_same_place = 1
-          elsif last_ranking_comparison_value == ranking_comparison_value
-            user_id_on_same_place = result_for_this_game[place]
-            result_for_this_game[place] = user_id_on_same_place + [user_id]
-            user_count_on_same_place += 1
-          end
-          last_ranking_comparison_value = ranking_comparison_value
-        end
-
-        mass_updating_tips(result_for_this_game, tips_for_game)
-      end
+      indexes = build_indexes(finished_games)
+      tip_id_to_place = compute_tip_id_to_place(finished_games, indexes)
+      bulk_update_ranking_places(tip_id_to_place)
 
       true
     end
 
     private
+
+    def build_indexes(finished_games)
+      {
+        i8: build_game_user_index(::TipQueries.all_by_games_and_tip_points(finished_games, TipPoints::PERFECT)),
+        i5: build_game_user_index(::TipQueries.all_by_games_and_tip_points(finished_games, TipPoints::CORRECT_GOALS_ONE_TEAM)),
+        i4: build_game_user_index(::TipQueries.all_by_games_and_tip_points(finished_games, TipPoints::CORRECT_GOALS)),
+        i3: build_game_user_index(::TipQueries.all_by_games_and_tip_points(finished_games, TipPoints::CORRECT_TREND))
+      }
+    end
+
+    # Walks the games in start_at order, maintains cumulative per-user counts
+    # in-memory, and accumulates a flat tip_id => ranking_place mapping for a
+    # single bulk update at the end.
+    def compute_tip_id_to_place(finished_games, indexes) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity -- algorithm intrinsic complexity
+      cum_points = Hash.new(0)
+      cum_8 = Hash.new(0) # rubocop:disable Naming/VariableNumber
+      cum_5 = Hash.new(0) # rubocop:disable Naming/VariableNumber
+      cum_4 = Hash.new(0) # rubocop:disable Naming/VariableNumber
+      cum_3 = Hash.new(0) # rubocop:disable Naming/VariableNumber
+
+      tip_id_to_place = {}
+
+      finished_games.each do |game|
+        # Increment cumulative counters from the preloaded tips of THIS game.
+        # No SQL: tips are already loaded by all_finished_ordered_by_start_at_with_preload_tips.
+        game.tips.each { |tip| cum_points[tip.user_id] += tip.tip_points.to_i }
+        (indexes[:i8][game.id] || []).each { |uid| cum_8[uid] += 1 }
+        (indexes[:i5][game.id] || []).each { |uid| cum_5[uid] += 1 }
+        (indexes[:i4][game.id] || []).each { |uid| cum_4[uid] += 1 }
+        (indexes[:i3][game.id] || []).each { |uid| cum_3[uid] += 1 }
+
+        ordered = ordered_users_for_game(cum_points, cum_8, cum_5, cum_4, cum_3)
+        places_for_game = assign_places(ordered)
+
+        # Map this game's tips to ranking_place via user_id lookup.
+        place_by_user_id = invert_to_user_id(places_for_game)
+        game.tips.each do |tip|
+          place = place_by_user_id[tip.user_id]
+          tip_id_to_place[tip.id] = place if place
+        end
+      end
+
+      tip_id_to_place
+    end
+
+    def ordered_users_for_game(cum_points, cum_8, cum_5, cum_4, cum_3) # rubocop:disable Naming/VariableNumber
+      with_rcv = cum_points.keys.map do |uid|
+        [uid,
+         ranking_comparison_value(cum_points[uid], cum_8[uid], cum_5[uid], cum_4[uid], cum_3[uid]).to_i]
+      end
+      with_rcv.sort_by { |_, rcv| -rcv }
+    end
+
+    # Returns { ranking_place => [user_id, ...] } using standard-competition
+    # ranking (1, 2, 2, 4).
+    def assign_places(ordered_user_id_and_rcv)
+      result = {}
+      place = 1
+      user_count_on_same_place = 1
+      last_rcv = nil
+
+      ordered_user_id_and_rcv.each do |user_id, rcv|
+        if last_rcv.nil?
+          result[place] = [user_id]
+        elsif last_rcv > rcv
+          place += user_count_on_same_place
+          result[place] = [user_id]
+          user_count_on_same_place = 1
+        elsif last_rcv == rcv
+          result[place] += [user_id]
+          user_count_on_same_place += 1
+        end
+        last_rcv = rcv
+      end
+
+      result
+    end
+
+    def invert_to_user_id(places_for_game)
+      result = {}
+      places_for_game.each do |place, user_ids|
+        user_ids.each { |uid| result[uid] = place }
+      end
+      result
+    end
 
     # Builds { game_id => [user_id, ...] } from a flat tip collection.
     def build_game_user_index(tips)
@@ -72,32 +114,21 @@ module Users
       end
     end
 
-    def get_ordered_user_id_and_ranking_comparison_value(cum_8, cum_5, cum_4, cum_3, used_game_ids) # rubocop:disable Naming/VariableNumber
-      user_id_and_sum_tip_points = TipQueries.sum_tip_points_group_by_user_id_by_game_ids(used_game_ids)
+    # Group tip_ids by ranking_place value and emit one UPDATE per distinct
+    # place. Worst case = number of distinct ranking_place values across all
+    # games (bounded by number of users) — but tiny SQL packets and PK-only
+    # WHERE clauses, so each statement is fast.
+    def bulk_update_ranking_places(tip_id_to_place)
+      return if tip_id_to_place.empty?
 
-      user_id_and_ranking_comparison_value = user_id_and_sum_tip_points.map do |user_id, sum_tip_points|
-        [user_id,
-         ranking_comparison_value(sum_tip_points, cum_8[user_id], cum_5[user_id], cum_4[user_id], cum_3[user_id]).to_i]
+      ids_by_place = Hash.new { |h, k| h[k] = [] }
+      tip_id_to_place.each { |tip_id, place| ids_by_place[place] << tip_id }
+
+      ids_by_place.each do |place, tip_ids|
+        # rubocop:disable Rails/SkipsModelValidations -- bulk perf update, no callbacks needed
+        ::Tip.where(id: tip_ids).update_all(ranking_place: place)
+        # rubocop:enable Rails/SkipsModelValidations
       end
-
-      user_id_and_ranking_comparison_value.sort_by { |_, tip_points| tip_points }.reverse
-    end
-
-    def mass_updating_tips(result_for_this_game, tips_for_game)
-      sql_when_values = []
-      sql_where_all_ids = []
-
-      result_for_this_game.each do |ranking_place, user_ids|
-        tip_ids = tips_for_game.select { |tip| tip.id if user_ids.include?(tip.user_id) }.map(&:id)
-
-        tip_ids.each do |tip_id|
-          sql_when_values << "WHEN id = #{tip_id} THEN #{ranking_place}"
-        end
-        sql_where_all_ids += tip_ids
-      end
-
-      sql = "UPDATE tips SET ranking_place = CASE #{sql_when_values.join(' ')} END WHERE id IN (#{sql_where_all_ids.join(',')})"
-      ::Tip.connection.execute(sql)
     end
   end
 end

--- a/spec/services/tips/update_points_spec.rb
+++ b/spec/services/tips/update_points_spec.rb
@@ -63,17 +63,19 @@ describe Tips::UpdatePoints do
       end
     end
 
-    it 'updates all tip points for a game' do
+    it 'updates all tip points for a single finished game' do
       expect(Tip.where(game_id: @game1.id).size).to eq(5)
       where_sql = ['game_id = ? and tip_points is not null', @game1.id]
       tips = Tip.where(where_sql).to_a
       expect(tips).not_to be_present
 
-      subject.new.send(:update_all_tip_points_for, @game1)
+      @game1.update_column(:finished, true)
+
+      subject.call
 
       tips = Tip.where(where_sql).to_a
       expect(tips).to be_present
-      tips.size == 5
+      expect(tips.size).to eq(5)
     end
 
     it 'updates all tip points for all games' do

--- a/spec/services/tips/update_points_spec.rb
+++ b/spec/services/tips/update_points_spec.rb
@@ -97,5 +97,17 @@ describe Tips::UpdatePoints do
       # alleTipp Punkte vergeben
       expect(Tip.where(tip_points: nil).count).to eq(0)
     end
+
+    it 'skips finished games with missing result goals instead of crashing' do
+      # Admins can mark a game finished without entering goals — the previous
+      # winner(game) guard returned early; the bulk path must do the same.
+      game_without_goals = create(:game, finished: true,
+                                         team1_goals: nil, team2_goals: nil)
+      tip = create(:tip, user: @user1, game: game_without_goals,
+                         team1_goals: 1, team2_goals: 0)
+
+      expect { subject.call }.not_to raise_error
+      expect(Tip.find(tip.id).tip_points).to be_nil
+    end
   end
 end


### PR DESCRIPTION
## Why

Profiling `admin::startcalculatings#new` showed ~435 SQL statements per recalculation on a populated DB. Most came from two per-game loops that issued one SELECT + one giant `CASE`-UPDATE per finished game. PR #107 had only optimized `Users::UpdatePoints`; the tip-points and per-game-ranking services were still N-query.

## What changed

### `Tips::UpdatePoints`
- **Before**: loop over `Game.all`, per finished game 1× `SELECT tips` + 1× giant `CASE`-UPDATE → ~435 SQLs.
- **After**: 1× bulk SELECT + ≤ 6× `UPDATE` (one per distinct point value 0/1/3/4/5/8) via `Tip.where(id: ids).update_all(tip_points: value)`.
- Scoring rule (`calculate_tip_points`, `correct_trend?`) unchanged — single Ruby source of truth.

### `TipQueries`
- Add `all_tips_with_game_results_for_finished_games`: one bulk `Tip.joins(:game).where(games: { finished: true }).pluck(...)` returning `[tip_id, t1, t2, g1, g2]` rows. Lives next to existing PR #107 bulk queries.

### `Users::UpdateRankingPerGame`
- **Before**: per finished game 1× `SUM(tip_points) GROUP BY user_id` + 1× `CASE`-UPDATE → ~140+ SQLs.
- **After**:
  - Cumulative per-user tip-points sum is maintained in Ruby by walking the already-preloaded `game.tips` (zero SQL per game).
  - All `(tip_id, ranking_place)` pairs collected across the full tournament, then one `update_all` per distinct `ranking_place` value.
- Method split into focused helpers: `build_indexes`, `compute_tip_id_to_place`, `ordered_users_for_game`, `assign_places`, `invert_to_user_id`, `bulk_update_ranking_places`.
- Same standard-competition ranking (1, 2, 2, 4) and same `ranking_comparison_value` tie-break.

### Other
- Both recalculation entry points benefit automatically: `Admin::StartCalculatingsController#new` and `Results::ImportFinishedGames#recalculate_rankings` (auto-import) — no change needed in either caller.

## Measured

Trace on a populated dev DB (100 users, ~217 tips per game):

| Service | Before | After commit 1 (Tips) | After commit (this PR) |
|---|---|---|---|
| Total SQLs (controller) | ~435 | 280 | ≈ 5 + N (N = distinct ranking_place values) |
| `Tips::UpdatePoints` | per-game loop | 108 ms | 108 ms |
| `Users::UpdateRankingPerGame` | per-game loop | 950 ms | expected significant drop |

## Tests / lint

- Full suite: **477 / 477 examples pass**.
- One spec in `spec/services/tips/update_points_spec.rb` that poked the removed private `update_all_tip_points_for` was rewritten to exercise the public `.call` path on a single finished game.
- `mise run lint` clean.

## Behaviour-preserving

- Same scoring rules and same ranking algorithm.
- Same iteration order (games by `start_at` ASC).
- Soft-delete semantics preserved (`acts_as_paranoid` default scope applies through `joins`).