### PR TITLE
Revert passenger to ~> 6.0 (fix beta 502 on Uberspace CentOS 7)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,13 @@ gem 'uglifier'
 gem 'whenever', require: false # cron schedule for result imports
 
 group :development, :production do
-  gem 'passenger', '~> 6.1' # CVE-2025-26803 fixed in 6.1.x
+  # Pinned to 6.0.x: Passenger 6.1.x precompiled agent binaries require glibc >= 2.25,
+  # but our Uberspace host runs CentOS 7 with glibc 2.17. Passenger 6.1 then falls back
+  # to compiling the agent from source, which prompts interactively ("Compile with
+  # optimizations? [y/n]") — that hangs/exits under supervisord and breaks boot.
+  # Accepting CVE-2025-26803 (local-only privilege issue) as low risk on a single-tenant
+  # Uberspace account. Revisit when we move off CentOS 7 / upgrade Ruby post-World Cup.
+  gem 'passenger', '~> 6.0.20'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,8 +236,7 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    passenger (6.1.2)
-      logger (>= 1.7.0)
+    passenger (6.0.27)
       rack (>= 1.6.13)
       rackup (>= 1.0.1)
       rake (>= 12.3.3)
@@ -448,7 +447,7 @@ DEPENDENCIES
   minitest (< 6)
   mysql2 (~> 0.5.6)
   parallel (< 2)
-  passenger (~> 6.1)
+  passenger (~> 6.0.20)
   rack-livereload
   rack-mini-profiler
   rails (~> 6.1.7)


### PR DESCRIPTION
## Summary

Reverts `passenger` from `~> 6.1` (6.1.2) back to `~> 6.0.20` (resolves to 6.0.27).

## Why

Passenger 6.1.x precompiled agent binaries require **glibc ≥ 2.25**, but our Uberspace host runs **CentOS 7 with glibc 2.17**. When the agent download fails, Passenger 6.1 falls back to compiling the agent from source — but that compile is **interactive**, prompting:

```
Compile with optimizations? [y/n]:
```

Under `supervisord` the launcher has no stdin, the prompt receives EOF, the process exits, supervisord retries a few times, then gives up:

```
beta-tippspiel.soemo.org   FATAL   Exited too quickly (process log may have details)
```

This is what took **beta-tippspiel.soemo.org offline with 502 Bad Gateway** after the PR #121 deploy. The same failure would have hit production on the next deploy.

## What this PR does

- Pins `passenger` to `~> 6.0.20` so we stay on the last Passenger line that ships glibc 2.17–compatible binaries.
- Adds an inline comment explaining the constraint and why we are accepting the security trade-off.

## Security trade-off

This re-introduces **CVE-2025-26803** (fixed in 6.1.x). It is a **local privilege issue** with no remote vector and no exploitation path on our single-tenant Uberspace account. Accepting as low risk three weeks before the World Cup. We will revisit when we move off CentOS 7 (post-World Cup, alongside Ruby 3.3 / Rails upgrade).

## Verification

- `mise run lint` — 182 files, no offenses
- `mise run test` — 477 examples, 0 failures, 96.54% line coverage
- Beta server was manually unblocked (interactive source compile completed once, cached in `~/.passenger/`), confirming the root cause matches this diagnosis.

## Out of scope

- Long-term Passenger 6.1 support (will come back once we leave CentOS 7).
- Pre-build / cache automation for the source-compiled agent (rejected as fragile; reverting is the smaller, safer change before the World Cup).
