### PR TITLE
Fix sendmail_settings arguments for mail gem 2.9.0

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,7 +81,7 @@ Rails.application.configure do
   #  Hier gefunden:
   #  https://github.com/mikel/mail/issues/70#issuecomment-2639987
   config.action_mailer.sendmail_settings = {
-    arguments: '-i'
+    arguments: %w[-i]
   }
   config.action_mailer.delivery_method = :sendmail
 


### PR DESCRIPTION
## Problem

User registration (and any mail delivery) on production fails with a 500 error:

```
ArgumentError (:arguments expected to be an Array of individual string args)
mail (2.9.0) lib/mail/network/delivery_methods/sendmail.rb:53:in `initialize'
```

Stack trace originates from `Devise::Mailer#confirmation_instructions` after a successful `POST /users`.

## Cause

The `mail` gem 2.9.0 changed the sendmail delivery method to require `:arguments` as an **Array of individual string args**. Our config in `config/environments/production.rb` was passing a String (`'-i'`).

## Fix

`arguments: '-i'` → `arguments: %w[-i]`

## Risk

Minimal — same semantic value, just the shape the gem now requires.