### PR TITLE
add AppSignal monitoring, remove lograge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,5 @@ WEBSITE_URL='https://tippspiel.example.org'
 # Free tier allows ~10 requests/minute, which is more than enough for the
 # manual admin-triggered WC result import.
 FOOTBALL_DATA_API_TOKEN=''
+
+APPSIGNAL_PUSH_API_KEY=

--- a/Capfile
+++ b/Capfile
@@ -22,3 +22,5 @@ require 'capistrano/maintenance'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
+
+require 'appsignal/capistrano'

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ ruby '3.2.11'
 # gem 'psych', '< 4' # https://stackoverflow.com/a/71192990
 
 gem 'acts_as_paranoid'
-gem "appsignal"
+gem 'appsignal'
 gem 'autoprefixer-rails' # Erweitert CSS um Vendor-Prefixe z.B: "-webkit-" oder "-moz-"
 gem 'cancancan'
 gem 'devise'

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ ruby '3.2.11'
 # gem 'psych', '< 4' # https://stackoverflow.com/a/71192990
 
 gem 'acts_as_paranoid'
+gem "appsignal"
 gem 'autoprefixer-rails' # Erweitert CSS um Vendor-Prefixe z.B: "-webkit-" oder "-moz-"
 gem 'cancancan'
 gem 'devise'
@@ -24,7 +25,6 @@ gem 'foundation-rails', '= 6.2.4.0'
 gem 'haml', '= 5.2.2'
 gem 'haml-rails'
 gem 'jquery-rails'
-gem 'lograge'
 gem 'mysql2', '~> 0.5.6' # keep on 0.5.x; explicit encoding: utf8mb4 in database.yml
 gem 'sass-rails', '= 5.1.0' # TODO: upgrade later to sassc-rails
 gem 'uglifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,9 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     airbrussh (1.6.1)
       sshkit (>= 1.6.1, != 1.7.0)
+    appsignal (4.8.4)
+      logger
+      rack (>= 2.0.0)
     ast (2.4.3)
     autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
@@ -186,11 +189,6 @@ GEM
       rexml
     lint_roller (1.1.0)
     logger (1.7.0)
-    lograge (0.14.0)
-      actionpack (>= 4)
-      activesupport (>= 4)
-      railties (>= 4)
-      request_store (~> 1.0)
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -291,8 +289,6 @@ GEM
     rainbow (3.1.1)
     rake (13.4.2)
     regexp_parser (2.12.0)
-    request_store (1.7.0)
-      rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -424,6 +420,7 @@ PLATFORMS
 
 DEPENDENCIES
   acts_as_paranoid
+  appsignal
   autoprefixer-rails
   bcrypt_pbkdf (>= 1.0, < 2.0)
   cancancan
@@ -443,7 +440,6 @@ DEPENDENCIES
   haml-rails
   jquery-rails
   letter_opener_web
-  lograge
   minitest (< 6)
   mysql2 (~> 0.5.6)
   parallel (< 2)

--- a/config/appsignal.rb
+++ b/config/appsignal.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 # AppSignal Ruby gem configuration
 # Visit our documentation for a list of all available configuration options.
 # https://docs.appsignal.com/ruby/configuration/options.html
 Appsignal.configure do |config|
-  config.activate_if_environment("development", "production")
-  config.name = "Tippspiel"
-  config.push_api_key = ENV.fetch("APPSIGNAL_PUSH_API_KEY", nil)
+  config.activate_if_environment('development', 'production')
+  config.name = 'Tippspiel'
+  config.push_api_key = ENV.fetch('APPSIGNAL_PUSH_API_KEY', nil)
 
   # Use shared log directory managed by Capistrano
-  config.log_path = Rails.root.join("log").to_s
+  config.log_path = Rails.root.join('log').to_s
 
   # Explicit working dir (AppSignal agent socket/pid files)
-  config.working_directory_path = "/tmp/appsignal"
+  config.working_directory_path = '/tmp/appsignal'
 
   # Configure actions that should not be monitored by AppSignal.
   # For more information see our docs:

--- a/config/appsignal.rb
+++ b/config/appsignal.rb
@@ -1,0 +1,24 @@
+# AppSignal Ruby gem configuration
+# Visit our documentation for a list of all available configuration options.
+# https://docs.appsignal.com/ruby/configuration/options.html
+Appsignal.configure do |config|
+  config.activate_if_environment("development", "production")
+  config.name = "Tippspiel"
+  config.push_api_key = ENV.fetch("APPSIGNAL_PUSH_API_KEY", nil)
+
+  # Use shared log directory managed by Capistrano
+  config.log_path = Rails.root.join("log").to_s
+
+  # Explicit working dir (AppSignal agent socket/pid files)
+  config.working_directory_path = "/tmp/appsignal"
+
+  # Configure actions that should not be monitored by AppSignal.
+  # For more information see our docs:
+  # https://docs.appsignal.com/ruby/configuration/ignore-actions.html
+  # config.ignore_actions << "ApplicationController#isup"
+
+  # Configure errors that should not be recorded by AppSignal.
+  # For more information see our docs:
+  # https://docs.appsignal.com/ruby/configuration/ignore-errors.html
+  # config.ignore_errors << "MyCustomError"
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,13 +111,6 @@ Rails.application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 
-  # better Log-Output https://github.com/roidrage/lograge
-  config.lograge.enabled = true
-  # add time to lograge
-  config.lograge.custom_options = lambda do |event|
-    { time: event.time }
-  end
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 

--- a/spec/controllers/admin/result_imports_controller_spec.rb
+++ b/spec/controllers/admin/result_imports_controller_spec.rb
@@ -119,6 +119,66 @@ describe Admin::ResultImportsController do
         expect(flash[:error]).to be_present
         expect(response).to redirect_to admin_games_path
       end
+
+      # ---- Point calculation after game finishes ----
+      #
+      # The controller delegates everything to Results::ImportFinishedGames.
+      # When at least one game transitions to finished=true the service runs
+      # the full ranking pipeline (Tips::UpdatePoints → Users::UpdatePoints →
+      # Users::UpdateRankingPerGame) inside a single transaction.
+      # These tests verify that the controller correctly triggers the service
+      # and that the ranking services are called exactly once per import run.
+
+      it 'triggers point recalculation when a game is newly finished' do
+        allow(Results::ImportFinishedGames).to receive(:call).and_call_original
+        allow(Tips::UpdatePoints).to receive(:call)
+        allow(Users::UpdatePoints).to receive(:call)
+        allow(Users::UpdateRankingPerGame).to receive(:call)
+
+        ger = create(:team, name: 'Germany', football_data_tla: 'GER')
+        bra = create(:team, name: 'Brazil',  football_data_tla: 'BRA')
+        create(:game,
+               team1: ger, team2: bra,
+               start_at: 2.hours.ago,
+               finished: false, team1_goals: 0, team2_goals: 0,
+               football_data_match_id: 42_001)
+
+        fake_client = double('client')
+        allow(fake_client).to receive(:fetch_competition_matches).and_return({
+          'matches' => [{
+            'id' => 42_001,
+            'utcDate' => 2.hours.ago.iso8601,
+            'status' => 'FINISHED',
+            'homeTeam' => { 'tla' => 'GER' },
+            'awayTeam' => { 'tla' => 'BRA' },
+            'score' => { 'duration' => 'REGULAR', 'fullTime' => { 'home' => 2, 'away' => 1 } }
+          }]
+        })
+        allow(Results::FootballDataClient).to receive(:new).and_return(fake_client)
+        allow(ResultsMailer).to receive(:import_summary).and_return(double(deliver_now: true))
+
+        post :create
+
+        expect(assigns(:result).imported.size).to eq 1
+        expect(assigns(:result).imported.first.game.finished?).to be true
+        expect(Tips::UpdatePoints).to have_received(:call).once
+        expect(Users::UpdatePoints).to have_received(:call).once
+        expect(Users::UpdateRankingPerGame).to have_received(:call).once
+      end
+
+      it 'does not trigger point recalculation when no game was newly finished' do
+        allow(Tips::UpdatePoints).to receive(:call)
+        allow(Users::UpdatePoints).to receive(:call)
+        allow(Users::UpdateRankingPerGame).to receive(:call)
+
+        allow(Results::ImportFinishedGames).to receive(:call).and_return(empty_result)
+
+        post :create
+
+        expect(Tips::UpdatePoints).not_to have_received(:call)
+        expect(Users::UpdatePoints).not_to have_received(:call)
+        expect(Users::UpdateRankingPerGame).not_to have_received(:call)
+      end
     end
   end
 end

--- a/spec/controllers/admin/result_imports_controller_spec.rb
+++ b/spec/controllers/admin/result_imports_controller_spec.rb
@@ -145,15 +145,15 @@ describe Admin::ResultImportsController do
 
         fake_client = double('client')
         allow(fake_client).to receive(:fetch_competition_matches).and_return({
-          'matches' => [{
-            'id' => 42_001,
-            'utcDate' => 2.hours.ago.iso8601,
-            'status' => 'FINISHED',
-            'homeTeam' => { 'tla' => 'GER' },
-            'awayTeam' => { 'tla' => 'BRA' },
-            'score' => { 'duration' => 'REGULAR', 'fullTime' => { 'home' => 2, 'away' => 1 } }
-          }]
-        })
+                                                                               'matches' => [{
+                                                                                 'id' => 42_001,
+                                                                                 'utcDate' => 2.hours.ago.iso8601,
+                                                                                 'status' => 'FINISHED',
+                                                                                 'homeTeam' => { 'tla' => 'GER' },
+                                                                                 'awayTeam' => { 'tla' => 'BRA' },
+                                                                                 'score' => { 'duration' => 'REGULAR', 'fullTime' => { 'home' => 2, 'away' => 1 } }
+                                                                               }]
+                                                                             })
         allow(Results::FootballDataClient).to receive(:new).and_return(fake_client)
         allow(ResultsMailer).to receive(:import_summary).and_return(double(deliver_now: true))
 


### PR DESCRIPTION
## AppSignal Monitoring

Adds AppSignal APM for error tracking and performance monitoring in production and development environments. Removes lograge as it is superseded by AppSignal's logging.

### Changes

- Add `appsignal` gem
- Add `config/appsignal.rb` — configure for production and development, API key via `APPSIGNAL_PUSH_API_KEY` env var
- Add `require 'appsignal/capistrano'` to `Capfile` for deploy tracking
- Remove `lograge` gem and its production config

