### PR TITLE
stay on current page after language switch

### DIFF
--- a/app/controllers/locales_controller.rb
+++ b/app/controllers/locales_controller.rb
@@ -19,24 +19,29 @@ class LocalesController < ApplicationController
     referer = request.referer
     return fallback_locale_path if referer.blank?
 
-    # Only redirect back if the referer resolves to a routable GET path.
-    # Devise's registration POST renders at /users which has no GET route —
-    # redirecting back there would trigger a RoutingError.
     referer_path = URI.parse(referer).path
-    begin
-      match = Rails.application.routes.router.recognize({ 'REQUEST_METHOD' => 'GET', 'PATH_INFO' => referer_path,
-                                                          'rack.input' => StringIO.new }) do |route, _|
-        route
-      end
-      match ? referer : fallback_locale_path
-    rescue StandardError
+
+    # Signed-in users can always go back to where they were.
+    # Unauthenticated users may only return to public pages to avoid an
+    # authenticate_user! redirect loop.
+    if user_signed_in? || public_path?(referer_path)
+      referer
+    else
       fallback_locale_path
     end
   rescue URI::InvalidURIError
     fallback_locale_path
   end
 
+  def public_path?(path)
+    public_controllers = %w[devise/sessions devise/registrations imprints helps]
+    route_info = Rails.application.routes.recognize_path(path, method: :get)
+    public_controllers.include?(route_info[:controller])
+  rescue ActionController::RoutingError, ActionController::MethodNotAllowed, NoMethodError
+    false
+  end
+
   def fallback_locale_path
-    user_signed_in? ? root_path : new_user_registration_path
+    user_signed_in? ? root_path : new_user_session_path
   end
 end

--- a/spec/controllers/locales_controller_spec.rb
+++ b/spec/controllers/locales_controller_spec.rb
@@ -5,24 +5,23 @@ require 'rails_helper'
 describe LocalesController do
   let(:current_user) { create(:active_user) }
 
-  before { login current_user }
+  # HTTP_REFERER must be a full URL; Rails controller specs use 'http://test.host' as default host.
+  def referer(path)
+    "http://test.host#{path}"
+  end
 
   describe 'PATCH #update' do
     context 'with a supported locale (en)' do
       it 'stores locale in session' do
+        login current_user
         patch :update, params: { locale: 'en' }
         expect(session[:locale]).to eq('en')
-      end
-
-      it 'redirects back' do
-        request.env['HTTP_REFERER'] = root_path
-        patch :update, params: { locale: 'en' }
-        expect(response).to redirect_to(root_path)
       end
     end
 
     context 'with a supported locale (de)' do
       it 'stores locale in session' do
+        login current_user
         patch :update, params: { locale: 'de' }
         expect(session[:locale]).to eq('de')
       end
@@ -30,8 +29,69 @@ describe LocalesController do
 
     context 'with an unsupported locale' do
       it 'stores de as fallback in session' do
+        login current_user
         patch :update, params: { locale: 'fr' }
         expect(session[:locale]).to eq('de')
+      end
+    end
+
+    context 'redirect behaviour when signed in' do
+      before { login current_user }
+
+      it 'redirects back to a protected page (e.g. /rankings)' do
+        request.env['HTTP_REFERER'] = referer(rankings_path)
+        patch :update, params: { locale: 'en' }
+        expect(response).to redirect_to(referer(rankings_path))
+      end
+
+      it 'redirects back to a protected page (e.g. /comparetips)' do
+        request.env['HTTP_REFERER'] = referer(compare_tips_path)
+        patch :update, params: { locale: 'en' }
+        expect(response).to redirect_to(referer(compare_tips_path))
+      end
+
+      it 'redirects back to root' do
+        request.env['HTTP_REFERER'] = referer(root_path)
+        patch :update, params: { locale: 'en' }
+        expect(response).to redirect_to(referer(root_path))
+      end
+
+      it 'redirects to root when referer is blank' do
+        request.env['HTTP_REFERER'] = nil
+        patch :update, params: { locale: 'en' }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'redirect behaviour when not signed in' do
+      it 'redirects back to the sign-in page' do
+        request.env['HTTP_REFERER'] = referer(new_user_session_path)
+        patch :update, params: { locale: 'en' }
+        expect(response).to redirect_to(referer(new_user_session_path))
+      end
+
+      it 'redirects back to the imprint page' do
+        request.env['HTTP_REFERER'] = referer(imprint_path)
+        patch :update, params: { locale: 'en' }
+        expect(response).to redirect_to(referer(imprint_path))
+      end
+
+      it 'redirects back to the help page' do
+        request.env['HTTP_REFERER'] = referer(help_path)
+        patch :update, params: { locale: 'en' }
+        expect(response).to redirect_to(referer(help_path))
+      end
+
+      it 'redirects to sign-in when referer is blank' do
+        request.env['HTTP_REFERER'] = nil
+        patch :update, params: { locale: 'en' }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it 'redirects to sign-in when referer is a protected page' do
+        request.env['HTTP_REFERER'] = referer(rankings_path)
+        patch :update, params: { locale: 'en' }
+        expect(response).to redirect_to(new_user_session_path)
       end
     end
   end


### PR DESCRIPTION
## fix(locale): stay on current page after language switch

### Problem

Switching language via the locale switcher always redirected to `/`
instead of staying on the current page. Unauthenticated users were also
incorrectly redirected to `/users/sign_up` instead of the sign-in page.

Root cause: the original `safe_return_path` used `router.recognize` with
a block whose return value was silently discarded, so `match` was always
`nil` and every request fell through to `fallback_locale_path`.

### Solution

- Replaced the broken `router.recognize` route check with a simple
  auth-based guard: signed-in users always return to their referer;
  unauthenticated users return to their referer only if it resolves to a
  known public controller (sign-in, sign-up, imprint, help).
- Fixed `fallback_locale_path` for unauthenticated users:
  `new_user_registration_path` → `new_user_session_path`.
- Added 12 controller specs covering all redirect scenarios for both
  signed-in and unauthenticated users.