### PR TITLE
fix: replace Rails.root with File.expand_path in appsignal config

### DIFF
--- a/config/appsignal.rb
+++ b/config/appsignal.rb
@@ -9,7 +9,7 @@ Appsignal.configure do |config|
   config.push_api_key = ENV.fetch('APPSIGNAL_PUSH_API_KEY', nil)
 
   # Use shared log directory managed by Capistrano
-  config.log_path = Rails.root.join('log').to_s
+  config.log_path = File.expand_path('../log', __dir__)
 
   # Explicit working dir (AppSignal agent socket/pid files)
   config.working_directory_path = '/tmp/appsignal'


### PR DESCRIPTION
## Fix AppSignal config loading error in CI

`config/appsignal.rb` referenced `Rails.root` which is not available when
AppSignal loads its config file during asset precompilation. This caused
the deploy to log:

> NameError: uninitialized constant Rails

### Change

Replace `Rails.root.join('log').to_s` with `File.expand_path('../log', __dir__)`
which resolves to the same path using only Ruby stdlib.