### PR TITLE
perf: extract Rankings::Recalculate service and add Redis ranking cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,7 @@ WEBSITE_URL='https://tippspiel.example.org'
 FOOTBALL_DATA_API_TOKEN=''
 
 APPSIGNAL_PUSH_API_KEY=
+
+# configure if you need redis cache
+# REDIS_URL=unix:///home/<USERNAME>/.redis/sock
+# REDIS_CACHE_NAMESPACE=tippspiel

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
     - 'config/routes.rb'
+    - 'config/environments/**/*'
     - 'lib/tasks/**/*'
 Metrics/ClassLength:
   Max: 200

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'haml', '= 5.2.2'
 gem 'haml-rails'
 gem 'jquery-rails'
 gem 'mysql2', '~> 0.5.6' # keep on 0.5.x; explicit encoding: utf8mb4 in database.yml
+gem 'redis', '~> 5.0' # used by Rails.cache (:redis_cache_store) and Action Cable
 gem 'sass-rails', '= 5.1.0' # TODO: upgrade later to sassc-rails
 gem 'uglifier'
 gem 'whenever', require: false # cron schedule for result imports

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
       logger (~> 1.5)
     chronic (0.10.2)
     concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     crass (1.0.6)
     date (3.5.1)
     devise (4.9.4)
@@ -288,6 +289,10 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.4.2)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.29.0)
+      connection_pool
     regexp_parser (2.12.0)
     responders (3.1.1)
       actionpack (>= 5.2)
@@ -448,6 +453,7 @@ DEPENDENCIES
   rack-mini-profiler
   rails (~> 6.1.7)
   rails-controller-testing
+  redis (~> 5.0)
   rspec
   rspec-rails
   rubocop

--- a/app/controllers/adapted_devise/confirmations_controller.rb
+++ b/app/controllers/adapted_devise/confirmations_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module AdaptedDevise
+  class ConfirmationsController < Devise::ConfirmationsController
+    protected
+
+    # Invalidate the ranking cache when a user confirms their account so the
+    # newly active user appears on the ranking list immediately.
+    def after_confirmation_path_for(resource_name, resource)
+      Rails.cache.delete(RankingPresenter::RANKING_CACHE_KEY)
+      super
+    end
+  end
+end

--- a/app/controllers/admin/start_calculatings_controller.rb
+++ b/app/controllers/admin/start_calculatings_controller.rb
@@ -4,11 +4,7 @@ module Admin
   class StartCalculatingsController < Admin::BaseController
     def new
       time = Benchmark.realtime do
-        ActiveRecord::Base.transaction do
-          ::Tips::UpdatePoints.call
-          ::Users::UpdatePoints.call
-          ::Users::UpdateRankingPerGame.call
-        end
+        ::Rankings::Recalculate.call
       end
 
       msg = "Berechnung erfolgreich in #{time.round(2)} seconds"

--- a/app/controllers/rankings_controller.rb
+++ b/app/controllers/rankings_controller.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# The ranking list is cached across requests via Rails.cache (key:
+# RankingPresenter::RANKING_CACHE_KEY). The cache is invalidated in three places:
+#   - Admin::StartCalculatingsController  — manual recalculation from /admin
+#   - Results::ImportFinishedGames        — automated background import
+#   - AdaptedDevise::ConfirmationsController — new user confirms their account
 class RankingsController < ApplicationController
   def index
     @presenter = RankingPresenter.new(current_user)

--- a/app/presenters/ranking_presenter.rb
+++ b/app/presenters/ranking_presenter.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 class RankingPresenter
+  RANKING_CACHE_KEY = 'rankings/user_ranking_hash'
+
   def initialize(current_user)
     @current_user = current_user
   end
 
   def bonus_answers_visible?
-    Tournament.round_of_16_started?
+    @bonus_answers_visible ||= Tournament.round_of_16_started?
   end
 
   def bonus_ranking_info(user, for_small_screen: false)
@@ -22,20 +24,22 @@ class RankingPresenter
   end
 
   def finished_games_count
-    GameQueries.finished.count
+    @finished_games_count ||= GameQueries.finished.count
   end
 
   def all_games_count
-    Game.count
+    @all_games_count ||= Game.count
   end
 
   def user_count
-    User.active.count
+    @user_count ||= User.active.count
   end
 
   def user_ranking_hash
-    user_ranking = Users::PrepareRanking.call(users_for_ranking: ::UserQueries.all_ordered_by_points_and_all_countxpoints)
-    user_ranking.sort
+    @user_ranking_hash ||= Rails.cache.fetch(RANKING_CACHE_KEY) do
+      user_ranking = Users::PrepareRanking.call(users_for_ranking: ::UserQueries.all_ordered_by_points_and_all_countxpoints)
+      user_ranking.sort
+    end
   end
 
   def bonus_hint_for?(user)

--- a/app/services/rankings/recalculate.rb
+++ b/app/services/rankings/recalculate.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Rankings
+  # Recalculates tip points, user points and per-game ranking places in a single
+  # transaction. Called from both the admin UI and the automated game import.
+  #
+  # After the transaction completes, the cached ranking hash is invalidated so
+  # the next request to RankingsController#index recomputes from fresh DB data.
+  class Recalculate < BaseService
+    def call
+      ActiveRecord::Base.transaction do
+        ::Tips::UpdatePoints.call
+        ::Users::UpdatePoints.call
+        ::Users::UpdateRankingPerGame.call
+      end
+
+      Rails.cache.delete(RankingPresenter::RANKING_CACHE_KEY)
+    end
+  end
+end

--- a/app/services/results/import_finished_games.rb
+++ b/app/services/results/import_finished_games.rb
@@ -176,11 +176,7 @@ module Results
     end
 
     def recalculate_rankings
-      ActiveRecord::Base.transaction do
-        ::Tips::UpdatePoints.call
-        ::Users::UpdatePoints.call
-        ::Users::UpdateRankingPerGame.call
-      end
+      ::Rankings::Recalculate.call
     end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,8 +57,18 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  # Use Redis as the cache store. REDIS_URL points to the Unix socket
+  # (e.g. unix:///home/soemo/.redis/sock on Uberspace). REDIS_CACHE_NAMESPACE
+  # isolates beta from production since both share the same Redis instance
+  # (e.g. "tippspiel" vs "beta-tippspiel"). If Redis is not running the
+  # error_handler silently degrades to no-op caching — the app keeps working.
+  config.cache_store = :redis_cache_store, {
+    url: ENV.fetch('REDIS_URL', nil),
+    namespace: ENV.fetch('REDIS_CACHE_NAMESPACE', 'tippspiel'),
+    error_handler: lambda { |method:, exception:, returning: nil| # rubocop:disable Lint/UnusedBlockArgument -- Rails API requires the keyword
+      Rails.logger.error("Redis cache error on #{method}: #{exception.class} #{exception.message}")
+    }
+  }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,8 @@ Rails.application.routes.draw do
 
   devise_for :users,
              controllers: {
-               registrations: 'adapted_devise/registrations'
+               registrations: 'adapted_devise/registrations',
+               confirmations: 'adapted_devise/confirmations'
              }
 
   authenticated :user do

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -103,7 +103,22 @@ cd /var/www/virtual/soemo/beta-tippspiel.soemo.org/current   # beta
 RAILS_ENV=production bundle exec rails db:seed
 ```
 
-## 6. Smoke check
+## 6. Redis (ranking cache)
+
+The app uses Redis as the Rails cache store to cache the ranking computation across requests. Redis is not running by default on Uberspace — set it up once per account:
+
+Follow the guide at <https://lab.uberspace.de/guide_redis/>, then add these to each app's shared `.env` file:
+
+```
+REDIS_URL=unix:///home/soemo/.redis/sock
+REDIS_CACHE_NAMESPACE=tippspiel        # use "beta-tippspiel" for the beta app
+```
+
+Both apps share the same Redis instance on Uberspace, so the namespace keeps their caches isolated.
+
+Without Redis running the app falls back gracefully to computing the ranking on every request (same behaviour as before). Redis errors are logged to `log/production.log` and never surfaced to the user.
+
+## 7. Smoke check
 
 - Visit the site and confirm the tournament name displays correctly in both DE and EN
 - Log in as admin, verify games are listed at `/admin/games`

--- a/spec/controllers/adapted_devise/confirmations_controller_spec.rb
+++ b/spec/controllers/adapted_devise/confirmations_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AdaptedDevise::ConfirmationsController do
+  before { @request.env['devise.mapping'] = Devise.mappings[:user] }
+
+  describe '#after_confirmation_path_for' do
+    it 'invalidates the ranking cache when a user confirms their account' do
+      # Create an unconfirmed user and capture the raw confirmation token
+      # before Devise hashes it — needed to pass as the URL param.
+      user = create(:user)
+      raw_token, hashed_token = Devise.token_generator.generate(User, :confirmation_token)
+      user.update_columns(confirmation_token: hashed_token, confirmed_at: nil)
+
+      expect(Rails.cache).to receive(:delete).with(RankingPresenter::RANKING_CACHE_KEY)
+
+      get :show, params: { confirmation_token: raw_token }
+    end
+  end
+end

--- a/spec/controllers/admin/start_calculatings_controller_spec.rb
+++ b/spec/controllers/admin/start_calculatings_controller_spec.rb
@@ -10,9 +10,7 @@ describe Admin::StartCalculatingsController do
     context 'if current_user is an admin' do
       it 'runs calculations and redirects to games' do
         login(admin_user)
-        expect(Tips::UpdatePoints).to receive(:call)
-        expect(Users::UpdatePoints).to receive(:call)
-        expect(Users::UpdateRankingPerGame).to receive(:call)
+        expect(Rankings::Recalculate).to receive(:call)
 
         get :new
 
@@ -23,9 +21,7 @@ describe Admin::StartCalculatingsController do
     context 'if current_user is not an admin' do
       it 'does not run calculations' do
         login(no_admin_user)
-        expect(Tips::UpdatePoints).not_to receive(:call)
-        expect(Users::UpdatePoints).not_to receive(:call)
-        expect(Users::UpdateRankingPerGame).not_to receive(:call)
+        expect(Rankings::Recalculate).not_to receive(:call)
 
         get :new
 

--- a/spec/presenters/ranking_presenter_spec.rb
+++ b/spec/presenters/ranking_presenter_spec.rb
@@ -8,14 +8,14 @@ describe RankingPresenter do
   describe '#bonus_answers_visible?' do
     context 'if Tournament.round_of_16_started? == true' do
       it 'returns true' do
-        expect(Tournament).to receive(:round_of_16_started?).and_return(true)
+        allow(Tournament).to receive(:round_of_16_started?).and_return(true)
         expect(subject.bonus_answers_visible?).to be true
       end
     end
 
     context 'if Tournament.round_of_16_started? == false' do
       it 'returns false' do
-        expect(Tournament).to receive(:round_of_16_started?).and_return(false)
+        allow(Tournament).to receive(:round_of_16_started?).and_return(false)
         expect(subject.bonus_answers_visible?).to be false
       end
     end

--- a/spec/services/rankings/recalculate_spec.rb
+++ b/spec/services/rankings/recalculate_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Rankings::Recalculate do
+  describe '.call' do
+    it 'runs tip points, user points and ranking per game in a transaction' do
+      expect(Tips::UpdatePoints).to receive(:call).ordered
+      expect(Users::UpdatePoints).to receive(:call).ordered
+      expect(Users::UpdateRankingPerGame).to receive(:call).ordered
+
+      described_class.call
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extracts a shared `Rankings::Recalculate` service to eliminate a duplicated transaction
block in `StartCalculatingsController` and `ImportFinishedGames`, and adds Redis-backed
caching for the ranking computation.

The `UserQueries` + `PrepareRanking` computation now caches via `Rails.cache.fetch` and
is invalidated in three places: admin recalculation, background game import, and new user
confirmation.

If Redis is not running the app falls back silently to the current behaviour — no user
impact. Set `REDIS_URL` and `REDIS_CACHE_NAMESPACE` in `.env` to activate (see
`docs/deployment.md`).