### PR TITLE
Add search filter to ranking page

### DIFF
--- a/app/assets/stylesheets/table_filter.scss
+++ b/app/assets/stylesheets/table_filter.scss
@@ -1,4 +1,4 @@
-#table-filter-input {
+.js-table-filter-input {
   background: url(image_path('filter.png')) no-repeat 5px 50%;
   width: 100%;
   padding: 8px 8px 8px 30px;

--- a/app/views/rankings/_user_ranking.html.haml
+++ b/app/views/rankings/_user_ranking.html.haml
@@ -1,6 +1,10 @@
 - user_ranking_hash = presenter.user_ranking_hash
 - if user_ranking_hash.present?
 
+  = text_field_tag('search', nil, {id: 'ranking-table-filter-input',
+                    class: 'js-table-filter-input',
+                    data: {table: 'ranking'},
+                    placeholder: I18n.t(:type_to_filter)})
   %table.ranking.hover
     %thead.hide-for-small-only
       %tr.white-bg

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -89,7 +89,7 @@ de:
   bonus_settings_submit: "Bonusantworten speichern"
 
   update_successful: "%{object_name} wurde aktualisiert."
-  type_to_filter: Tippen um zu Filtern
+  type_to_filter: Filter bei Namen
 
   bonus_questions:
     which_team_is_champion: '1. Welche Mannschaft wird das Turnier gewinnen?'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,7 +100,7 @@ en:
   result_after_game_count: "after %{finished_games_count} / %{all_games_count} games"
 
   show_only_today_games: Show only today's games.
-  type_to_filter: Tap to filter
+  type_to_filter: Filter by name
 
   your_statistic: Your statistic
   statistic_for: Statistic for %{name}

--- a/spec/views/ranking/index.html.haml_spec.rb
+++ b/spec/views/ranking/index.html.haml_spec.rb
@@ -19,6 +19,9 @@ describe 'rankings/index' do
     expect(rendered).to have_css('h3', text: I18n.t('ranking'))
     expect(rendered).to have_css('p', text: I18n.t('x_user_bet', user_count: 0))
     expect(rendered).to have_css('p', text: I18n.t('no_user'))
+
+    # no ranking table means no filter input
+    expect(rendered).to have_no_field(id: 'ranking-table-filter-input')
   end
 
   it 'shows correct user ranking - all user on place 1' do
@@ -45,6 +48,12 @@ describe 'rankings/index' do
 
     expect(rendered).to have_css('h3', text: I18n.t('ranking'))
     expect(rendered).to have_css('p', text: I18n.t('x_user_bet', user_count: user_size))
+
+    # search filter input on top of the ranking table
+    expect(rendered).to have_css(
+      "input#ranking-table-filter-input.js-table-filter-input[data-table='ranking']" \
+      "[placeholder='#{I18n.t(:type_to_filter)}']"
+    )
 
     expect(rendered).to have_css('table.ranking.hover') do |table| # rubocop:disable Capybara/RSpec/SpecificMatcher -- table has CSS classes that have_table doesn't support
       expect(table).to have_css('thead') do |thead|


### PR DESCRIPTION
## Summary

Adds a search filter on top of the **Ranking** table, mirroring the filter already used on the **Compare tips** page. Users can quickly find a participant by typing their name; matching rows are shown, others hidden (multi-word AND search, works for both mobile and desktop layouts).

## Changes

- **`app/views/rankings/_user_ranking.html.haml`** — Render the shared `.js-table-filter-input` above the ranking table (only when there are ranked users). Reuses the already-loaded `initTableFilter()` from `table_filter.js`; targets the existing `.ranking` table via `data-table`.
- **`app/assets/stylesheets/table_filter.scss`** — Switch the selector from `#table-filter-input` to the shared class `.js-table-filter-input` so both the ranking and compare-tips inputs get the filter icon + styling.
- **`config/locales/en.yml` / `config/locales/de.yml`** — Update the shared `type_to_filter` placeholder to **"Filter by name" / "Filter bei Namen"** (applies to both filters).
- **`spec/views/ranking/index.html.haml_spec.rb`** — View specs: filter input present when there are rows; absent in the no-user case.

## Testing

- Ranking view specs: 3 examples, 0 failures
- `rubocop`: no offenses

No new JS/locale keys; the filter widget was already generic.