### PR TITLE
Show total points and point badges on the user statistics page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,4 +22,5 @@
 @import 'nav';
 @import 'points';
 @import 'ranking';
+@import 'statistic_points';
 @import 'table_filter';

--- a/app/assets/stylesheets/statistic_points.scss
+++ b/app/assets/stylesheets/statistic_points.scss
@@ -1,0 +1,22 @@
+.statistic-points-summary {
+  margin-top: 5px;
+
+  .user-points {
+    font-size: 2rem;
+    margin-right: 5px;
+
+    @include breakpoint(medium down) {
+      font-size: 1.5rem;
+    }
+  }
+
+  .badge,
+  .user-statistic {
+    vertical-align: text-bottom;
+  }
+
+  .badge-bonus {
+    color: $eight-point-color;
+    background: $bonus-point-color;
+  }
+}

--- a/app/presenters/statistics_show_presenter.rb
+++ b/app/presenters/statistics_show_presenter.rb
@@ -21,6 +21,14 @@ class StatisticsShowPresenter
     user_id.present? && user_id.to_i == current_user.id
   end
 
+  def total_points
+    user_to_show.points || 0
+  end
+
+  def points_header_text
+    User.human_attribute_name('points')
+  end
+
   def finished_tips
     TipQueries.all_by_user_id_and_game_ids_ordered_games_start_at(user_to_show.id, @finished_games.map(&:id))
   end
@@ -42,7 +50,11 @@ class StatisticsShowPresenter
   end
 
   def ranking_summary_header_text
-    I18n.t(:ranking_summary_header)
+    if shows_current_user_rankings?
+      I18n.t(:ranking_summary_header)
+    else
+      I18n.t(:ranking_summary_header_other)
+    end
   end
 
   def tips_header_text

--- a/app/views/rankings/index.html.haml
+++ b/app/views/rankings/index.html.haml
@@ -9,25 +9,7 @@
       = hall_of_fame_link
       = '.'
       %br
-      %small
-        %span.point-explaining
-          = icon('fas', 'circle', '', class: 'eight-point-color')
-          = "#{TipPoints::PERFECT} #{t('points_abbr')}"
-        %span.point-explaining
-          = icon('fas', 'circle', '', class: 'five-point-color')
-          = "#{TipPoints::CORRECT_GOALS_ONE_TEAM} #{t('points_abbr')}"
-        %span.point-explaining
-          = icon('fas', 'circle', '', class: 'four-point-color')
-          = "#{TipPoints::CORRECT_GOALS} #{t('points_abbr')}"
-        %span.point-explaining
-          = icon('fas', 'circle', '', class: 'three-point-color')
-          = "#{TipPoints::CORRECT_TREND} #{t('points_abbr')}"
-        %span.point-explaining
-          = icon('fas', 'circle', '', class: 'null-point-color')
-          = "#{TipPoints::NO_POINTS} #{t('points_abbr')}"
-        %span.point-explaining
-          = icon('fas', 'circle', '', class: 'badge-bonus bonus-point-color')
-          = User.human_attribute_name('bonuspoints_small')
+      = render 'shared/point_legend'
 
 
 

--- a/app/views/shared/_point_legend.html.haml
+++ b/app/views/shared/_point_legend.html.haml
@@ -1,0 +1,19 @@
+%small
+  %span.point-explaining
+    = icon('fas', 'circle', '', class: 'eight-point-color')
+    = "#{TipPoints::PERFECT} #{t('points_abbr')}"
+  %span.point-explaining
+    = icon('fas', 'circle', '', class: 'five-point-color')
+    = "#{TipPoints::CORRECT_GOALS_ONE_TEAM} #{t('points_abbr')}"
+  %span.point-explaining
+    = icon('fas', 'circle', '', class: 'four-point-color')
+    = "#{TipPoints::CORRECT_GOALS} #{t('points_abbr')}"
+  %span.point-explaining
+    = icon('fas', 'circle', '', class: 'three-point-color')
+    = "#{TipPoints::CORRECT_TREND} #{t('points_abbr')}"
+  %span.point-explaining
+    = icon('fas', 'circle', '', class: 'null-point-color')
+    = "#{TipPoints::NO_POINTS} #{t('points_abbr')}"
+  %span.point-explaining
+    = icon('fas', 'circle', '', class: 'badge-bonus bonus-point-color')
+    = User.human_attribute_name('bonuspoints_small')

--- a/app/views/statistics/show.html.haml
+++ b/app/views/statistics/show.html.haml
@@ -3,6 +3,12 @@
     %h3=@presenter.header_text
 
     - if @presenter.data_to_show?
+      %h4.statistic-points-header=@presenter.points_header_text
+      %p.statistic-points-summary
+        %span.user-points= @presenter.total_points
+        %span.user-statistic= statistic_content(@presenter.user_to_show).html_safe
+      = render 'shared/point_legend'
+
       -# Mobile: summary stats (small only)
       .show-for-small-only
         %h4=@presenter.ranking_summary_header_text

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -131,6 +131,7 @@ de:
   show_statistic_for: Statistik für %{name} anzeigen
   ranking_per_game: Platzierung pro Spiel
   ranking_summary_header: Deine Platzierung
+  ranking_summary_header_other: Platzierung
   ranking_per_game_nothing_to_show: Aktuell liegen keine Daten vor. Bitte schau nach dem nächsten Spiel nochmal vorbei.
   ranking_current: Aktuell
   ranking_best: Beste

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,7 @@ en:
   show_statistic_for: Show statistic for %{name}
   ranking_per_game: Ranking per game
   ranking_summary_header: Your ranking
+  ranking_summary_header_other: Ranking
   ranking_per_game_nothing_to_show: No data available yet. Please check back after the next game.
   ranking_current: Current
   ranking_best: Best

--- a/spec/presenters/statistics_show_presenter_spec.rb
+++ b/spec/presenters/statistics_show_presenter_spec.rb
@@ -280,4 +280,41 @@ describe StatisticsShowPresenter do
       end
     end
   end
+
+  describe '#total_points' do
+    it 'returns the points of the user to show' do
+      user.update!(points: 168)
+      presenter = subject.new(current_user, user.id, games)
+      expect(presenter.total_points).to eq(168)
+    end
+
+    it 'returns 0 when the user has no points' do
+      user.update!(points: nil)
+      presenter = subject.new(current_user, user.id, games)
+      expect(presenter.total_points).to eq(0)
+    end
+  end
+
+  describe '#points_header_text' do
+    it 'returns the localized points label' do
+      presenter = subject.new(current_user, user.id, games)
+      expect(presenter.points_header_text).to eq(User.human_attribute_name('points'))
+    end
+  end
+
+  describe '#ranking_summary_header_text' do
+    context 'when showing the current user' do
+      it 'returns the personal "Your ranking" label' do
+        presenter = subject.new(current_user, current_user.id, games)
+        expect(presenter.ranking_summary_header_text).to eq(I18n.t(:ranking_summary_header))
+      end
+    end
+
+    context 'when showing another user' do
+      it 'returns the neutral ranking label' do
+        presenter = subject.new(current_user, user.id, games)
+        expect(presenter.ranking_summary_header_text).to eq(I18n.t(:ranking_summary_header_other))
+      end
+    end
+  end
 end

--- a/spec/views/statistics/show.html.haml_spec.rb
+++ b/spec/views/statistics/show.html.haml_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'statistics/show' do
+  let(:presenter) { StatisticsShowPresenter.new(nil, nil, []) }
+
+  let(:user_to_show) do
+    build(:user,
+          lastname: 'stats_user',
+          points: 168,
+          count8points: 6,
+          count5points: 9,
+          count4points: 3,
+          count3points: 12,
+          count0points: 9,
+          bonus_points: 0)
+  end
+
+  def stub_common_presenter_methods
+    allow(presenter).to receive_messages(
+      header_text: I18n.t(:your_statistic),
+      points_header_text: User.human_attribute_name('points'),
+      total_points: 168,
+      user_to_show: user_to_show,
+      ranking_summary_header_text: 'Summary',
+      ranking_current: 80, ranking_best: 51, ranking_worst: 101,
+      ranking_current_date: '01.07.', ranking_best_date: '12.06.', ranking_worst_date: '15.06.',
+      line_chart_header_text: 'Chart',
+      tips_header_text: I18n.t(:tips),
+      finished_tips: [],
+      line_chart_data: { labels: [], datasets: [{}] },
+      line_chart_options: { plugins: { tooltip: {} } }
+    )
+  end
+
+  context 'when there is data to show' do
+    before do
+      allow(presenter).to receive(:data_to_show?).and_return(true)
+      stub_common_presenter_methods
+      assign(:presenter, presenter)
+    end
+
+    it 'shows the total points of the user' do
+      render
+
+      expect(rendered).to have_css('h4.statistic-points-header', text: User.human_attribute_name('points'))
+      expect(rendered).to have_css('.statistic-points-summary span.user-points', text: '168')
+    end
+
+    it 'shows a point badge for every point category and the bonus' do
+      render
+
+      expect(rendered).to have_css('.statistic-points-summary span.badge', count: 6)
+      expect(rendered).to have_css('.statistic-points-summary span.badge.eight-point-background-color', text: '6')
+      expect(rendered).to have_css('.statistic-points-summary span.badge.five-point-background-color', text: '9')
+      expect(rendered).to have_css('.statistic-points-summary span.badge.four-point-background-color', text: '3')
+      expect(rendered).to have_css('.statistic-points-summary span.badge.three-point-background-color', text: '12')
+      expect(rendered).to have_css('.statistic-points-summary span.badge.null-point-background-color', text: '9')
+      expect(rendered).to have_css('.statistic-points-summary span.badge.badge-bonus', text: '0')
+    end
+
+    it 'shows the point legend' do
+      render
+
+      expect(rendered).to have_css('.point-explaining', count: 6)
+    end
+  end
+
+  context 'when there is no data to show' do
+    before do
+      allow(presenter).to receive_messages(header_text: I18n.t(:your_statistic), data_to_show?: false)
+      assign(:presenter, presenter)
+    end
+
+    it 'does not show the points summary' do
+      render
+
+      expect(rendered).to have_no_css('.statistic-points-summary')
+      expect(rendered).to have_css('p', text: I18n.t(:ranking_per_game_nothing_to_show))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

On a user's statistics page, show their **total points** and the **point badges** (how many 8 / 5 / 4 / 3 / 0 point tips, plus bonus) — the same badges already shown in the ranking list. A colour legend is included so the badges are self-explanatory.

Also fixes a wording bug: the mobile ranking summary heading said *"Your ranking" / "Deine Platzierung"* even when viewing **another** user's statistics. It now reads *"Ranking" / "Platzierung"* for other users.

## Changes

- **`app/views/statistics/show.html.haml`** — Add a points + badges summary (total points, reusing the existing `statistic_content` helper) plus the colour legend, shown above the ranking summary when there is data.
- **`app/views/shared/_point_legend.html.haml`** — Extract the point-colour legend (previously inline on the ranking page) into a shared partial.
- **`app/views/rankings/index.html.haml`** — Render the shared legend partial (no visual change).
- **`app/presenters/statistics_show_presenter.rb`** — Add `total_points` and `points_header_text`; make `ranking_summary_header_text` context-aware for other users.
- **`config/locales/{en,de}.yml`** — Add `ranking_summary_header_other` (`Ranking` / `Platzierung`).
- **`app/assets/stylesheets/statistic_points.scss`** — Scoped styling for the new summary (points size + bonus badge colour), mirroring the ranking styles.

## Testing

- New view spec `spec/views/statistics/show.html.haml_spec.rb`
- Presenter specs for `total_points`, `points_header_text`, and context-aware `ranking_summary_header_text`
- Full suite: 503 examples, 0 failures
- `rubocop`: 191 files, no offenses